### PR TITLE
Feature/wit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anyhow"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+
+[[package]]
+name = "async-trait"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +147,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "itertools"
@@ -163,6 +195,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -180,6 +213,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "num-traits"
@@ -216,6 +255,17 @@ name = "protobuf"
 version = "2.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
 
 [[package]]
 name = "quote"
@@ -403,6 +453,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +502,12 @@ name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -455,3 +550,64 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wit-bindgen-gen-core"
+version = "0.1.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=380b6f2a6442451173b3d7aa6a083af901dd57a0#380b6f2a6442451173b3d7aa6a083af901dd57a0"
+dependencies = [
+ "anyhow",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-gen-rust"
+version = "0.1.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=380b6f2a6442451173b3d7aa6a083af901dd57a0#380b6f2a6442451173b3d7aa6a083af901dd57a0"
+dependencies = [
+ "heck",
+ "wit-bindgen-gen-core",
+]
+
+[[package]]
+name = "wit-bindgen-gen-rust-wasm"
+version = "0.1.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=380b6f2a6442451173b3d7aa6a083af901dd57a0#380b6f2a6442451173b3d7aa6a083af901dd57a0"
+dependencies = [
+ "heck",
+ "wit-bindgen-gen-core",
+ "wit-bindgen-gen-rust",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.1.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=380b6f2a6442451173b3d7aa6a083af901dd57a0#380b6f2a6442451173b3d7aa6a083af901dd57a0"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "wit-bindgen-rust-impl",
+]
+
+[[package]]
+name = "wit-bindgen-rust-impl"
+version = "0.1.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=380b6f2a6442451173b3d7aa6a083af901dd57a0#380b6f2a6442451173b3d7aa6a083af901dd57a0"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "wit-bindgen-gen-core",
+ "wit-bindgen-gen-rust-wasm",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.1.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=380b6f2a6442451173b3d7aa6a083af901dd57a0#380b6f2a6442451173b3d7aa6a083af901dd57a0"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "pulldown-cmark",
+ "unicode-normalization",
+ "unicode-xid",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rmp-serde = "^0.15"
 bincode = "^1.3"
 protobuf = "^2.25"
 paste = "1.0"
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "380b6f2a6442451173b3d7aa6a083af901dd57a0" }
 lunatic-macros = { version = "^0.9", path = "./lunatic-macros" }
 lunatic-test = { version = "^0.9", path = "./lunatic-test" }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,10 +125,10 @@ impl ProcessConfig {
         unsafe {
             host::api::wasi::config_add_environment_variable(
                 self.id() as u64,
-                key.as_ptr(),
-                key.len(),
-                value.as_ptr(),
-                value.len(),
+                key.as_ptr() as u32,
+                key.len() as u32,
+                value.as_ptr() as u32,
+                value.len() as u32,
             )
         }
     }
@@ -138,15 +138,21 @@ impl ProcessConfig {
         unsafe {
             host::api::wasi::config_add_command_line_argument(
                 self.id() as u64,
-                argument.as_ptr(),
-                argument.len(),
+                argument.as_ptr() as u32,
+                argument.len() as u32,
             )
         }
     }
 
     /// Mark a directory as preopened.
     pub fn preopen_dir(&self, dir: &str) {
-        unsafe { host::api::wasi::config_preopen_dir(self.id() as u64, dir.as_ptr(), dir.len()) }
+        unsafe {
+            host::api::wasi::config_preopen_dir(
+                self.id() as u64,
+                dir.as_ptr() as u32,
+                dir.len() as u32,
+            )
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ enum ProcessConfigType {
 impl Drop for ProcessConfigType {
     fn drop(&mut self) {
         match self {
-            ProcessConfigType::Config(id) => unsafe { host::api::process::drop_config(*id) },
+            ProcessConfigType::Config(id) => host::api::process::drop_config(*id),
             ProcessConfigType::Inherit => (),
         }
     }
@@ -44,7 +44,7 @@ impl ProcessConfig {
     /// There is no memory or fuel limit set on the newly created configuration, they are not
     /// inherited from parent.
     pub fn new() -> Self {
-        let id = unsafe { host::api::process::create_config() };
+        let id = host::api::process::create_config();
         Self(ProcessConfigType::Config(id))
     }
 
@@ -65,12 +65,12 @@ impl ProcessConfig {
     /// If a process tries to allocate more memory with `memory.grow`, the instruction is going to
     /// return -1.
     pub fn set_max_memory(&mut self, max_memory: u64) {
-        unsafe { host::api::process::config_set_max_memory(self.id() as u64, max_memory) };
+        host::api::process::config_set_max_memory(self.id() as u64, max_memory);
     }
 
     /// Returns the maximum amount of memory in bytes.
     pub fn get_max_memory(&self) -> u64 {
-        unsafe { host::api::process::config_get_max_memory(self.id() as u64) }
+        host::api::process::config_get_max_memory(self.id() as u64)
     }
 
     /// Sets the maximum amount of fuel available to the process.
@@ -78,22 +78,22 @@ impl ProcessConfig {
     /// One unit of fuel is approximately 100k wasm instructions. If a process runs out of fuel it
     /// will trap.
     pub fn set_max_fuel(&mut self, max_fuel: u64) {
-        unsafe { host::api::process::config_set_max_fuel(self.id() as u64, max_fuel) };
+        host::api::process::config_set_max_fuel(self.id() as u64, max_fuel);
     }
 
     /// Returns the maximum amount of fuel.
     pub fn get_max_fuel(&self) -> u64 {
-        unsafe { host::api::process::config_get_max_fuel(self.id() as u64) }
+        host::api::process::config_get_max_fuel(self.id() as u64)
     }
 
     /// Sets the ability of a process to compile WebAssembly modules.
     pub fn set_can_compile_modules(&mut self, can: bool) {
-        unsafe { host::api::process::config_set_can_compile_modules(self.id() as u64, can as u32) };
+        host::api::process::config_set_can_compile_modules(self.id() as u64, can as u32);
     }
 
     /// Returns true if processes can compile WebAssembly modules.
     pub fn can_compile_modules(&self) -> bool {
-        (unsafe { host::api::process::config_can_compile_modules(self.id() as u64) }) > 0
+        host::api::process::config_can_compile_modules(self.id() as u64) > 0
     }
 
     /// Sets the ability of a process to create their own sub-configuration.
@@ -102,57 +102,47 @@ impl ProcessConfig {
     /// possibility to create new configurations, it can spawn sub-processes using a new config
     /// that has the permission enabled.
     pub fn set_can_create_configs(&mut self, can: bool) {
-        unsafe { host::api::process::config_set_can_create_configs(self.id() as u64, can as u32) };
+        host::api::process::config_set_can_create_configs(self.id() as u64, can as u32);
     }
 
     /// Returns true if processes can create their own configurations.
     pub fn can_create_configs(&self) -> bool {
-        (unsafe { host::api::process::config_can_create_configs(self.id() as u64) }) > 0
+        host::api::process::config_can_create_configs(self.id() as u64) > 0
     }
 
     /// Sets the ability of a process to spawn sub-processes.
     pub fn set_can_spawn_processes(&mut self, can: bool) {
-        unsafe { host::api::process::config_set_can_spawn_processes(self.id() as u64, can as u32) };
+        host::api::process::config_set_can_spawn_processes(self.id() as u64, can as u32);
     }
 
     /// Returns true if processes can spawn sub-processes.
     pub fn can_spawn_processes(&self) -> bool {
-        (unsafe { host::api::process::config_can_spawn_processes(self.id() as u64) }) > 0
+        host::api::process::config_can_spawn_processes(self.id() as u64) > 0
     }
 
     /// Adds environment variable.
     pub fn add_environment_variable(&mut self, key: &str, value: &str) {
-        unsafe {
-            host::api::wasi::config_add_environment_variable(
-                self.id() as u64,
-                key.as_ptr() as u32,
-                key.len() as u32,
-                value.as_ptr() as u32,
-                value.len() as u32,
-            )
-        }
+        host::api::wasi::config_add_environment_variable(
+            self.id() as u64,
+            key.as_ptr() as u32,
+            key.len() as u32,
+            value.as_ptr() as u32,
+            value.len() as u32,
+        )
     }
 
     /// Adds command line argument.
     pub fn add_command_line_argument(&mut self, argument: &str) {
-        unsafe {
-            host::api::wasi::config_add_command_line_argument(
-                self.id() as u64,
-                argument.as_ptr() as u32,
-                argument.len() as u32,
-            )
-        }
+        host::api::wasi::config_add_command_line_argument(
+            self.id() as u64,
+            argument.as_ptr() as u32,
+            argument.len() as u32,
+        )
     }
 
     /// Mark a directory as preopened.
     pub fn preopen_dir(&self, dir: &str) {
-        unsafe {
-            host::api::wasi::config_preopen_dir(
-                self.id() as u64,
-                dir.as_ptr() as u32,
-                dir.len() as u32,
-            )
-        }
+        host::api::wasi::config_preopen_dir(self.id() as u64, dir.as_ptr() as u32, dir.len() as u32)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ impl Debug for LunaticError {
             LunaticError::Error(id) => {
                 let size = unsafe { error::string_size(*id) };
                 let mut buff = vec![0; size as usize];
-                unsafe { error::to_string(*id, buff.as_mut_ptr()) };
+                unsafe { error::to_string(*id, buff.as_mut_ptr() as u32) };
                 let error = std::str::from_utf8(&buff).unwrap();
                 write!(f, "{}", error)
             }
@@ -52,7 +52,7 @@ impl Display for LunaticError {
             LunaticError::Error(id) => {
                 let size = unsafe { error::string_size(*id) };
                 let mut buff = vec![0; size as usize];
-                unsafe { error::to_string(*id, buff.as_mut_ptr()) };
+                unsafe { error::to_string(*id, buff.as_mut_ptr() as u32) };
                 let error = std::str::from_utf8(&buff).unwrap();
                 write!(f, "{}", error)
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ impl Drop for LunaticError {
     fn drop(&mut self) {
         match self {
             LunaticError::Error(id) => {
-                unsafe { error::drop(*id) };
+                error::drop(*id);
             }
             LunaticError::PermissionDenied => (),
         }
@@ -35,9 +35,9 @@ impl Debug for LunaticError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             LunaticError::Error(id) => {
-                let size = unsafe { error::string_size(*id) };
+                let size = error::string_size(*id);
                 let mut buff = vec![0; size as usize];
-                unsafe { error::to_string(*id, buff.as_mut_ptr() as u32) };
+                error::to_string(*id, buff.as_mut_ptr() as u32);
                 let error = std::str::from_utf8(&buff).unwrap();
                 write!(f, "{}", error)
             }
@@ -50,9 +50,9 @@ impl Display for LunaticError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             LunaticError::Error(id) => {
-                let size = unsafe { error::string_size(*id) };
+                let size = error::string_size(*id);
                 let mut buff = vec![0; size as usize];
-                unsafe { error::to_string(*id, buff.as_mut_ptr() as u32) };
+                error::to_string(*id, buff.as_mut_ptr() as u32);
                 let error = std::str::from_utf8(&buff).unwrap();
                 write!(f, "{}", error)
             }

--- a/src/function/process.rs
+++ b/src/function/process.rs
@@ -187,7 +187,7 @@ impl<M, S> Process<M, S> {
     /// Returns a globally unique process ID.
     pub fn uuid(&self) -> u128 {
         let mut uuid: [u8; 16] = [0; 16];
-        unsafe { host::api::process::id(self.id, &mut uuid as *mut [u8; 16] as u32) };
+        host::api::process::id(self.id, &mut uuid as *mut [u8; 16] as u32);
         u128::from_le_bytes(uuid)
     }
 
@@ -195,17 +195,17 @@ impl<M, S> Process<M, S> {
     pub fn link(&self) {
         // Don't use tags because a process' [`Mailbox`] can't differentiate between regular
         // messages and signals. Both processes should almost always die when a link is broken.
-        unsafe { host::api::process::link(0, self.id) };
+        host::api::process::link(0, self.id);
     }
 
     /// Unlink processes from the caller.
     pub fn unlink(&self) {
-        unsafe { host::api::process::unlink(self.id) };
+        host::api::process::unlink(self.id);
     }
 
     /// Kill this process
     pub fn kill(&self) {
-        unsafe { host::api::process::kill(self.id) };
+        host::api::process::kill(self.id);
     }
 
     /// Register process under a name.
@@ -217,7 +217,7 @@ impl<M, S> Process<M, S> {
             std::any::type_name::<M>(),
             std::any::type_name::<S>()
         );
-        unsafe { host::api::registry::put(name.as_ptr() as u32, name.len() as u32, self.id) };
+        host::api::registry::put(name.as_ptr() as u32, name.len() as u32, self.id);
     }
 
     /// Look up a process.
@@ -229,13 +229,11 @@ impl<M, S> Process<M, S> {
             std::any::type_name::<S>()
         );
         let mut id = 0;
-        let result = unsafe {
-            host::api::registry::get(
-                name.as_ptr() as u32,
-                name.len() as u32,
-                &mut id as *mut u64 as u32,
-            )
-        };
+        let result = host::api::registry::get(
+            name.as_ptr() as u32,
+            name.len() as u32,
+            &mut id as *mut u64 as u32,
+        );
         if result == 0 {
             unsafe { Some(Self::from_id(id)) }
         } else {
@@ -266,11 +264,11 @@ where
     /// with serializer `S`.
     pub fn send(&self, message: M) {
         // Create new message.
-        unsafe { host::api::message::create_data(Tag::none().id(), 0) };
+        host::api::message::create_data(Tag::none().id(), 0);
         // During serialization resources will add themself to the message.
         S::encode(&message).unwrap();
         // Send it!
-        unsafe { host::api::message::send(self.id) };
+        host::api::message::send(self.id);
     }
 
     /// Send a message to the process after the specified duration has passed.
@@ -281,12 +279,11 @@ where
     /// with serializer `S`.
     pub fn send_after(&self, message: M, duration: Duration) -> TimerRef {
         // Create new message.
-        unsafe { host::api::message::create_data(Tag::none().id(), 0) };
+        host::api::message::create_data(Tag::none().id(), 0);
         // During serialization resources will add themself to the message.
         S::encode(&message).unwrap();
         // Send it!
-        let timer_id =
-            unsafe { host::api::timer::send_after(self.id, duration.as_millis() as u64) };
+        let timer_id = host::api::timer::send_after(self.id, duration.as_millis() as u64);
         TimerRef::new(timer_id)
     }
 
@@ -298,11 +295,11 @@ where
     /// with serializer `S`.
     pub fn tag_send(&self, tag: Tag, message: M) {
         // Create new message.
-        unsafe { host::api::message::create_data(tag.id(), 0) };
+        host::api::message::create_data(tag.id(), 0);
         // During serialization resources will add themself to the message.
         S::encode(&message).unwrap();
         // Send it!
-        unsafe { host::api::message::send(self.id) };
+        host::api::message::send(self.id);
     }
 }
 
@@ -337,7 +334,7 @@ impl<M, S> std::fmt::Debug for Process<M, S> {
 
 impl<M, S> Clone for Process<M, S> {
     fn clone(&self) -> Self {
-        let id = unsafe { host::api::process::clone_process(self.id) };
+        let id = host::api::process::clone_process(self.id);
         unsafe { Process::from_id(id) }
     }
 }
@@ -346,7 +343,7 @@ impl<M, S> Drop for Process<M, S> {
     fn drop(&mut self) {
         // Only drop a process if it's not already consumed.
         if unsafe { !*self.consumed.get() } {
-            unsafe { host::api::process::drop_process(self.id) };
+            host::api::process::drop_process(self.id);
         }
     }
 }
@@ -359,7 +356,7 @@ impl<M, S> serde::Serialize for Process<M, S> {
         // Mark process as consumed.
         unsafe { self.consume() };
 
-        let index = unsafe { host::api::message::push_process(self.id) };
+        let index = host::api::message::push_process(self.id);
         serializer.serialize_u64(index)
     }
 }
@@ -379,7 +376,7 @@ impl<'de, M, S> serde::de::Visitor<'de> for ProcessVisitor<M, S> {
     where
         E: serde::de::Error,
     {
-        let id = unsafe { host::api::message::take_process(index) };
+        let id = host::api::message::take_process(index);
         Ok(unsafe { Process::from_id(id) })
     }
 }

--- a/src/function/process.rs
+++ b/src/function/process.rs
@@ -187,7 +187,7 @@ impl<M, S> Process<M, S> {
     /// Returns a globally unique process ID.
     pub fn uuid(&self) -> u128 {
         let mut uuid: [u8; 16] = [0; 16];
-        unsafe { host::api::process::id(self.id, &mut uuid as *mut [u8; 16]) };
+        unsafe { host::api::process::id(self.id, &mut uuid as *mut [u8; 16] as u32) };
         u128::from_le_bytes(uuid)
     }
 
@@ -217,7 +217,7 @@ impl<M, S> Process<M, S> {
             std::any::type_name::<M>(),
             std::any::type_name::<S>()
         );
-        unsafe { host::api::registry::put(name.as_ptr(), name.len(), self.id) };
+        unsafe { host::api::registry::put(name.as_ptr() as u32, name.len() as u32, self.id) };
     }
 
     /// Look up a process.
@@ -229,7 +229,13 @@ impl<M, S> Process<M, S> {
             std::any::type_name::<S>()
         );
         let mut id = 0;
-        let result = unsafe { host::api::registry::get(name.as_ptr(), name.len(), &mut id) };
+        let result = unsafe {
+            host::api::registry::get(
+                name.as_ptr() as u32,
+                name.len() as u32,
+                &mut id as *mut u64 as u32,
+            )
+        };
         if result == 0 {
             unsafe { Some(Self::from_id(id)) }
         } else {

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -1,175 +1,57 @@
 //! Lunatic VM host functions.
 
 pub mod error {
-    #[link(wasm_import_module = "lunatic::error")]
-    extern "C" {
-        pub fn string_size(error_id: u64) -> u32;
-        pub fn to_string(error_id: u64, error_str: *mut u8);
-        pub fn drop(error_id: u64);
-    }
+    wit_bindgen_rust::import!("wit/lunatic_error.wit");
+
+    #[doc(inline)]
+    pub use lunatic_error::*;
 }
 
 pub mod message {
-    #[link(wasm_import_module = "lunatic::message")]
-    extern "C" {
-        pub fn create_data(tag: i64, capacity: u64);
-        pub fn write_data(data: *const u8, data_len: usize) -> usize;
-        pub fn read_data(data: *mut u8, data_len: usize) -> usize;
-        #[allow(dead_code)]
-        pub fn seek_data(position: u64);
-        pub fn get_tag() -> i64;
-        #[allow(dead_code)]
-        pub fn data_size() -> u64;
-        pub fn push_process(process_id: u64) -> u64;
-        pub fn take_process(index: u64) -> u64;
-        pub fn push_tcp_stream(tcp_stream_id: u64) -> u64;
-        pub fn take_tcp_stream(index: u64) -> u64;
-        pub fn send(process_id: u64);
-        pub fn send_receive_skip_search(process_id: u64, timeout: u32) -> u32;
-        pub fn receive(tag: *const i64, tag_len: usize, timeout: u32) -> u32;
-    }
+    wit_bindgen_rust::import!("wit/lunatic_message.wit");
+
+    #[doc(inline)]
+    pub use lunatic_message::*;
 }
 
 pub mod timer {
-    #[link(wasm_import_module = "lunatic::timer")]
-    extern "C" {
-        pub fn send_after(process_id: u64, duration: u64) -> u64;
-        pub fn cancel_timer(timer_id: u64) -> u32;
-    }
+    wit_bindgen_rust::import!("wit/lunatic_timer.wit");
+
+    #[doc(inline)]
+    pub use lunatic_timer::*;
 }
 
 pub mod networking {
-    #[link(wasm_import_module = "lunatic::networking")]
-    extern "C" {
-        pub fn resolve(name_str: *const u8, name_str_len: usize, timeout: u32, id: *mut u64)
-            -> u32;
-        pub fn drop_dns_iterator(dns_iter_id: u64);
-        pub fn resolve_next(
-            dns_iter_id: u64,
-            addr_type: *mut u32,
-            addr: *mut u8,
-            port: *mut u16,
-            flow_info: *mut u32,
-            scope_id: *mut u32,
-        ) -> u32;
-        pub fn tcp_bind(
-            addr_type: u32,
-            addr: *const u8,
-            port: u32,
-            flow_info: u32,
-            scope_id: u32,
-            id: *mut u64,
-        ) -> u32;
-        pub fn udp_bind(
-            addr_type: u32,
-            addr: *const u8,
-            port: u32,
-            flow_info: u32,
-            scope_id: u32,
-            id: *mut u64,
-        ) -> u32;
-        pub fn drop_tcp_listener(tcp_listener_id: u64);
-        pub fn drop_udp_socket(udp_socket_id: u64);
-        pub fn tcp_local_addr(tcp_listener_id: u64, addr_dns_iter: *mut u64) -> u32;
-        pub fn udp_local_addr(udp_socket_id: u64, addr_dns_iter: *mut u64) -> u32;
-        pub fn tcp_accept(listener_id: u64, id: *mut u64, peer_dns_iter: *mut u64) -> u32;
-        pub fn tcp_connect(
-            addr_type: u32,
-            addr: *const u8,
-            port: u32,
-            flow_info: u32,
-            scope_id: u32,
-            timeout: u32,
-            id: *mut u64,
-        ) -> u32;
-        pub fn drop_tcp_stream(tcp_stream_id: u64);
-        pub fn clone_tcp_stream(tcp_stream_id: u64) -> u64;
-        pub fn tcp_write_vectored(
-            tcp_stream_id: u64,
-            ciovec_array: *const u32,
-            ciovec_array_len: usize,
-            timeout: u32,
-            opaque: *mut u64,
-        ) -> u32;
-        pub fn tcp_read(
-            tcp_stream_id: u64,
-            buffer: *mut u8,
-            buffer_len: usize,
-            timeout: u32,
-            opaque: *mut u64,
-        ) -> u32;
-        pub fn tcp_flush(tcp_stream_id: u64, error_id: *mut u64) -> u32;
-    }
+    wit_bindgen_rust::import!("wit/lunatic_networking.wit");
+
+    #[doc(inline)]
+    pub use lunatic_networking::*;
 }
 
 pub mod process {
-    #[link(wasm_import_module = "lunatic::process")]
-    extern "C" {
-        pub fn compile_module(data: *const u8, data_len: usize, id: *mut u64) -> i32;
-        pub fn drop_module(config_id: u64);
-        pub fn create_config() -> u64;
-        pub fn drop_config(config_id: u64);
-        pub fn config_set_max_memory(config_id: u64, max_memory: u64);
-        pub fn config_get_max_memory(config_id: u64) -> u64;
-        pub fn config_set_max_fuel(config_id: u64, max_fuel: u64);
-        pub fn config_get_max_fuel(config_id: u64) -> u64;
-        pub fn config_can_compile_modules(config_id: u64) -> u32;
-        pub fn config_set_can_compile_modules(config_id: u64, can: u32);
-        pub fn config_can_create_configs(config_id: u64) -> u32;
-        pub fn config_set_can_create_configs(config_id: u64, can: u32);
-        pub fn config_can_spawn_processes(config_id: u64) -> u32;
-        pub fn config_set_can_spawn_processes(config_id: u64, can: u32);
-        pub fn spawn(
-            link: i64,
-            config_id: i64,
-            module_id: i64,
-            function: *const u8,
-            function_len: usize,
-            params: *const u8,
-            params_len: usize,
-            id: *mut u64,
-        ) -> u32;
-        pub fn drop_process(process_id: u64);
-        pub fn clone_process(process_id: u64) -> u64;
-        pub fn sleep_ms(millis: u64);
-        pub fn die_when_link_dies(trap: u32);
-        pub fn this() -> u64;
-        pub fn id(process_id: u64, uuid: *mut [u8; 16]);
-        pub fn link(tag: i64, process_id: u64);
-        pub fn unlink(process_id: u64);
-        pub fn kill(process_id: u64);
-    }
+    wit_bindgen_rust::import!("wit/lunatic_process.wit");
+
+    #[doc(inline)]
+    pub use lunatic_process::*;
 }
 
 pub mod registry {
-    #[link(wasm_import_module = "lunatic::registry")]
-    extern "C" {
-        pub fn put(name: *const u8, name_len: usize, process_id: u64);
-        pub fn get(name: *const u8, name_len: usize, process_id: *mut u64) -> u32;
-        pub fn remove(name: *const u8, name_len: usize);
-    }
+    wit_bindgen_rust::import!("wit/lunatic_registry.wit");
+
+    #[doc(inline)]
+    pub use lunatic_registry::*;
 }
 
 pub mod wasi {
-    #[link(wasm_import_module = "lunatic::wasi")]
-    extern "C" {
-        pub fn config_add_environment_variable(
-            config_id: u64,
-            key: *const u8,
-            key_len: usize,
-            value: *const u8,
-            value_len: usize,
-        );
-        pub fn config_add_command_line_argument(config_id: u64, key: *const u8, key_len: usize);
-        pub fn config_preopen_dir(config_id: u64, key: *const u8, key_len: usize);
-    }
+    wit_bindgen_rust::import!("wit/lunatic_wasi.wit");
+
+    #[doc(inline)]
+    pub use lunatic_wasi::*;
 }
 
 pub mod version {
-    #[link(wasm_import_module = "lunatic::version")]
-    extern "C" {
-        pub fn major() -> u32;
-        pub fn minor() -> u32;
-        pub fn patch() -> u32;
-    }
+    wit_bindgen_rust::import!("wit/lunatic_version.wit");
+
+    #[doc(inline)]
+    pub use lunatic_version::*;
 }

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -36,11 +36,11 @@ pub(crate) fn spawn(
             link,
             config_id,
             WasmModule::inherit().id(),
-            func.as_ptr(),
-            func.len(),
-            params.as_ptr(),
-            params.len(),
-            &mut id,
+            func.as_ptr() as u32,
+            func.len() as u32,
+            params.as_ptr() as u32,
+            params.len() as u32,
+            &mut id as *mut u64 as u32,
         )
     };
     if result == 0 {

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -31,18 +31,16 @@ pub(crate) fn spawn(
         None => 0,
     };
     let config_id = config.map_or_else(|| ProcessConfig::inherit().id(), |config| config.id());
-    let result = unsafe {
-        api::process::spawn(
-            link,
-            config_id,
-            WasmModule::inherit().id(),
-            func.as_ptr() as u32,
-            func.len() as u32,
-            params.as_ptr() as u32,
-            params.len() as u32,
-            &mut id as *mut u64 as u32,
-        )
-    };
+    let result = api::process::spawn(
+        link,
+        config_id,
+        WasmModule::inherit().id(),
+        func.as_ptr() as u32,
+        func.len() as u32,
+        params.as_ptr() as u32,
+        params.len() as u32,
+        &mut id as *mut u64 as u32,
+    );
     if result == 0 {
         Ok(id)
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,5 +130,5 @@ pub trait Resource {
 
 /// Suspends the current process for `duration` of time.
 pub fn sleep(duration: std::time::Duration) {
-    unsafe { host::api::process::sleep_ms(duration.as_millis() as u64) };
+    host::api::process::sleep_ms(duration.as_millis() as u64);
 }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -91,8 +91,7 @@ where
             },
             None => 0,
         };
-        let message_type =
-            unsafe { message::receive(tags.as_ptr() as u32, tags.len() as u32, timeout_ms) };
+        let message_type = message::receive(tags.as_ptr() as u32, tags.len() as u32, timeout_ms);
         // Mailbox can't receive LINK_TRAPPED messages.
         assert_ne!(message_type, LINK_TRAPPED);
         // In case of timeout, return error.
@@ -182,11 +181,10 @@ where
             },
             None => 0,
         };
-        let message_type =
-            unsafe { message::receive(tags.as_ptr() as u32, tags.len() as u32, timeout_ms) };
+        let message_type = message::receive(tags.as_ptr() as u32, tags.len() as u32, timeout_ms);
         // If we received a LINK_TRAPPED message return
         if message_type == LINK_TRAPPED {
-            return Ok(Err(LinkTrapped(Tag::from(unsafe { message::get_tag() }))));
+            return Ok(Err(LinkTrapped(Tag::from(message::get_tag()))));
         }
         // In case of timeout, return error.
         if message_type == TIMEOUT {

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -91,7 +91,8 @@ where
             },
             None => 0,
         };
-        let message_type = unsafe { message::receive(tags.as_ptr(), tags.len(), timeout_ms) };
+        let message_type =
+            unsafe { message::receive(tags.as_ptr() as u32, tags.len() as u32, timeout_ms) };
         // Mailbox can't receive LINK_TRAPPED messages.
         assert_ne!(message_type, LINK_TRAPPED);
         // In case of timeout, return error.
@@ -181,7 +182,8 @@ where
             },
             None => 0,
         };
-        let message_type = unsafe { message::receive(tags.as_ptr(), tags.len(), timeout_ms) };
+        let message_type =
+            unsafe { message::receive(tags.as_ptr() as u32, tags.len() as u32, timeout_ms) };
         // If we received a LINK_TRAPPED message return
         if message_type == LINK_TRAPPED {
             return Ok(Err(LinkTrapped(Tag::from(unsafe { message::get_tag() }))));

--- a/src/module.rs
+++ b/src/module.rs
@@ -31,9 +31,9 @@ impl WasmModule {
 
         let result = unsafe {
             host::api::process::compile_module(
-                data.as_ptr(),
-                data.len(),
-                &mut module_or_error_id as *mut u64,
+                data.as_ptr() as u32,
+                data.len() as u32,
+                &mut module_or_error_id as *mut u64 as u32,
             )
         };
         if result == -1 {
@@ -72,13 +72,13 @@ impl WasmModule {
         let result = unsafe {
             host::api::process::spawn(
                 0,
-                -1,
+                -1i64,
                 self.id(),
-                function.as_ptr(),
-                function.len(),
-                params.as_ptr(),
-                params.len(),
-                &mut process_or_error_id as *mut u64,
+                function.as_ptr() as u32,
+                function.len() as u32,
+                params.as_ptr() as u32,
+                params.len() as u32,
+                &mut process_or_error_id as *mut u64 as u32,
             )
         };
 
@@ -103,13 +103,13 @@ impl WasmModule {
         let result = unsafe {
             host::api::process::spawn(
                 1,
-                -1,
+                -1i64,
                 self.id(),
-                function.as_ptr(),
-                function.len(),
-                params.as_ptr(),
-                params.len(),
-                &mut process_or_error_id as *mut u64,
+                function.as_ptr() as u32,
+                function.len() as u32,
+                params.as_ptr() as u32,
+                params.len() as u32,
+                &mut process_or_error_id as *mut u64 as u32,
             )
         };
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -14,7 +14,7 @@ impl Drop for WasmModule {
     fn drop(&mut self) {
         match self {
             WasmModule::Module(id) => {
-                unsafe { host::api::process::drop_module(*id) };
+                host::api::process::drop_module(*id);
             }
             WasmModule::Inherit => (),
         }
@@ -29,13 +29,11 @@ impl WasmModule {
     pub fn new(data: &[u8]) -> Result<Self, LunaticError> {
         let mut module_or_error_id: u64 = 0;
 
-        let result = unsafe {
-            host::api::process::compile_module(
-                data.as_ptr() as u32,
-                data.len() as u32,
-                &mut module_or_error_id as *mut u64 as u32,
-            )
-        };
+        let result = host::api::process::compile_module(
+            data.as_ptr() as u32,
+            data.len() as u32,
+            &mut module_or_error_id as *mut u64 as u32,
+        );
         if result == -1 {
             Err(LunaticError::PermissionDenied)
         } else if result != 0 {
@@ -69,18 +67,16 @@ impl WasmModule {
     {
         let mut process_or_error_id = 0;
         let params: Vec<u8> = params_to_vec(params);
-        let result = unsafe {
-            host::api::process::spawn(
-                0,
-                -1i64,
-                self.id(),
-                function.as_ptr() as u32,
-                function.len() as u32,
-                params.as_ptr() as u32,
-                params.len() as u32,
-                &mut process_or_error_id as *mut u64 as u32,
-            )
-        };
+        let result = host::api::process::spawn(
+            0,
+            -1i64,
+            self.id(),
+            function.as_ptr() as u32,
+            function.len() as u32,
+            params.as_ptr() as u32,
+            params.len() as u32,
+            &mut process_or_error_id as *mut u64 as u32,
+        );
 
         if result == 0 {
             Ok(unsafe { Process::from_id(process_or_error_id) })
@@ -100,18 +96,16 @@ impl WasmModule {
     {
         let mut process_or_error_id = 0;
         let params: Vec<u8> = params_to_vec(params);
-        let result = unsafe {
-            host::api::process::spawn(
-                1,
-                -1i64,
-                self.id(),
-                function.as_ptr() as u32,
-                function.len() as u32,
-                params.as_ptr() as u32,
-                params.len() as u32,
-                &mut process_or_error_id as *mut u64 as u32,
-            )
-        };
+        let result = host::api::process::spawn(
+            1,
+            -1i64,
+            self.id(),
+            function.as_ptr() as u32,
+            function.len() as u32,
+            params.as_ptr() as u32,
+            params.len() as u32,
+            &mut process_or_error_id as *mut u64 as u32,
+        );
 
         if result == 0 {
             Ok(unsafe { Process::from_id(process_or_error_id) })

--- a/src/net/resolver.rs
+++ b/src/net/resolver.rs
@@ -37,11 +37,11 @@ impl Iterator for SocketAddrIterator {
         let next = unsafe {
             host::api::networking::resolve_next(
                 self.id,
-                &mut addr_type as *mut u32,
-                addr.as_mut_ptr(),
-                &mut port as *mut u16,
-                &mut flowinfo as *mut u32,
-                &mut scope_id as *mut u32,
+                &mut addr_type as *mut u32 as u32,
+                addr.as_mut_ptr() as u32,
+                &mut port as *mut u16 as u16,
+                &mut flowinfo as *mut u32 as u32,
+                &mut scope_id as *mut u32 as u32,
             )
         };
 
@@ -93,10 +93,10 @@ fn resolve_timeout_(
     };
     let result = unsafe {
         host::api::networking::resolve(
-            name.as_ptr(),
-            name.len(),
+            name.as_ptr() as u32,
+            name.len() as u32,
             timeout_ms,
-            &mut dns_iter_or_error_id as *mut u64,
+            &mut dns_iter_or_error_id as *mut u64 as u64,
         )
     };
     if result != 0 {

--- a/src/net/resolver.rs
+++ b/src/net/resolver.rs
@@ -19,9 +19,7 @@ impl SocketAddrIterator {
 
 impl Drop for SocketAddrIterator {
     fn drop(&mut self) {
-        unsafe {
-            host::api::networking::drop_dns_iterator(self.id);
-        }
+        host::api::networking::drop_dns_iterator(self.id);
     }
 }
 
@@ -34,16 +32,14 @@ impl Iterator for SocketAddrIterator {
         let mut port: u16 = 0;
         let mut flowinfo: u32 = 0;
         let mut scope_id: u32 = 0;
-        let next = unsafe {
-            host::api::networking::resolve_next(
-                self.id,
-                &mut addr_type as *mut u32 as u32,
-                addr.as_mut_ptr() as u32,
-                &mut port as *mut u16 as u16,
-                &mut flowinfo as *mut u32 as u32,
-                &mut scope_id as *mut u32 as u32,
-            )
-        };
+        let next = host::api::networking::resolve_next(
+            self.id,
+            &mut addr_type as *mut u32 as u32,
+            addr.as_mut_ptr() as u32,
+            &mut port as *mut u16 as u16,
+            &mut flowinfo as *mut u32 as u32,
+            &mut scope_id as *mut u32 as u32,
+        );
 
         if next == 0 {
             match addr_type {
@@ -91,14 +87,12 @@ fn resolve_timeout_(
         },
         None => 0,
     };
-    let result = unsafe {
-        host::api::networking::resolve(
-            name.as_ptr() as u32,
-            name.len() as u32,
-            timeout_ms,
-            &mut dns_iter_or_error_id as *mut u64 as u64,
-        )
-    };
+    let result = host::api::networking::resolve(
+        name.as_ptr() as u32,
+        name.len() as u32,
+        timeout_ms,
+        &mut dns_iter_or_error_id as *mut u64 as u64,
+    );
     if result != 0 {
         Err(LunaticError::from(dns_iter_or_error_id))
     } else {

--- a/src/net/tcp_listener.rs
+++ b/src/net/tcp_listener.rs
@@ -73,11 +73,11 @@ impl TcpListener {
                     unsafe {
                         host::api::networking::tcp_bind(
                             4,
-                            ip.as_ptr(),
+                            ip.as_ptr() as u32,
                             port,
                             0,
                             0,
-                            &mut id as *mut u64,
+                            &mut id as *mut u64 as u64,
                         )
                     }
                 }
@@ -89,11 +89,11 @@ impl TcpListener {
                     unsafe {
                         host::api::networking::tcp_bind(
                             6,
-                            ip.as_ptr(),
+                            ip.as_ptr() as u32,
                             port,
                             flow_info,
                             scope_id,
-                            &mut id as *mut u64,
+                            &mut id as *mut u64 as u64,
                         )
                     }
                 }
@@ -117,8 +117,8 @@ impl TcpListener {
         let result = unsafe {
             host::api::networking::tcp_accept(
                 self.id,
-                &mut tcp_stream_or_error_id as *mut u64,
-                &mut dns_iter_id as *mut u64,
+                &mut tcp_stream_or_error_id as *mut u64 as u64,
+                &mut dns_iter_id as *mut u64 as u64,
             )
         };
         if result == 0 {
@@ -138,7 +138,10 @@ impl TcpListener {
     pub fn local_addr(&self) -> Result<SocketAddr> {
         let mut dns_iter_or_error_id = 0;
         let result = unsafe {
-            host::api::networking::tcp_local_addr(self.id, &mut dns_iter_or_error_id as *mut u64)
+            host::api::networking::tcp_local_addr(
+                self.id,
+                &mut dns_iter_or_error_id as *mut u64 as u64,
+            )
         };
         if result == 0 {
             let mut dns_iter = SocketAddrIterator::from(dns_iter_or_error_id);

--- a/src/net/tcp_listener.rs
+++ b/src/net/tcp_listener.rs
@@ -47,7 +47,7 @@ pub struct TcpListener {
 
 impl Drop for TcpListener {
     fn drop(&mut self) {
-        unsafe { host::api::networking::drop_tcp_listener(self.id) };
+        host::api::networking::drop_tcp_listener(self.id);
     }
 }
 
@@ -70,32 +70,28 @@ impl TcpListener {
                 SocketAddr::V4(v4_addr) => {
                     let ip = v4_addr.ip().octets();
                     let port = v4_addr.port() as u32;
-                    unsafe {
-                        host::api::networking::tcp_bind(
-                            4,
-                            ip.as_ptr() as u32,
-                            port,
-                            0,
-                            0,
-                            &mut id as *mut u64 as u64,
-                        )
-                    }
+                    host::api::networking::tcp_bind(
+                        4,
+                        ip.as_ptr() as u32,
+                        port,
+                        0,
+                        0,
+                        &mut id as *mut u64 as u64,
+                    )
                 }
                 SocketAddr::V6(v6_addr) => {
                     let ip = v6_addr.ip().octets();
                     let port = v6_addr.port() as u32;
                     let flow_info = v6_addr.flowinfo();
                     let scope_id = v6_addr.scope_id();
-                    unsafe {
-                        host::api::networking::tcp_bind(
-                            6,
-                            ip.as_ptr() as u32,
-                            port,
-                            flow_info,
-                            scope_id,
-                            &mut id as *mut u64 as u64,
-                        )
-                    }
+                    host::api::networking::tcp_bind(
+                        6,
+                        ip.as_ptr() as u32,
+                        port,
+                        flow_info,
+                        scope_id,
+                        &mut id as *mut u64 as u64,
+                    )
                 }
             };
             if result == 0 {
@@ -114,13 +110,11 @@ impl TcpListener {
     pub fn accept(&self) -> Result<(TcpStream, SocketAddr)> {
         let mut tcp_stream_or_error_id = 0;
         let mut dns_iter_id = 0;
-        let result = unsafe {
-            host::api::networking::tcp_accept(
-                self.id,
-                &mut tcp_stream_or_error_id as *mut u64 as u64,
-                &mut dns_iter_id as *mut u64 as u64,
-            )
-        };
+        let result = host::api::networking::tcp_accept(
+            self.id,
+            &mut tcp_stream_or_error_id as *mut u64 as u64,
+            &mut dns_iter_id as *mut u64 as u64,
+        );
         if result == 0 {
             let tcp_stream = TcpStream::from(tcp_stream_or_error_id);
             let mut dns_iter = SocketAddrIterator::from(dns_iter_id);
@@ -137,12 +131,10 @@ impl TcpListener {
     /// This can be useful, for example, to identify when binding to port 0 which port was assigned by the OS.
     pub fn local_addr(&self) -> Result<SocketAddr> {
         let mut dns_iter_or_error_id = 0;
-        let result = unsafe {
-            host::api::networking::tcp_local_addr(
-                self.id,
-                &mut dns_iter_or_error_id as *mut u64 as u64,
-            )
-        };
+        let result = host::api::networking::tcp_local_addr(
+            self.id,
+            &mut dns_iter_or_error_id as *mut u64 as u64,
+        );
         if result == 0 {
             let mut dns_iter = SocketAddrIterator::from(dns_iter_or_error_id);
             let addr = dns_iter.next().expect("must contain one element");

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -167,12 +167,12 @@ impl TcpStream {
                     unsafe {
                         host::api::networking::tcp_connect(
                             4,
-                            ip.as_ptr(),
+                            ip.as_ptr() as u32,
                             port,
                             0,
                             0,
                             timeout_ms,
-                            &mut id as *mut u64,
+                            &mut id as *mut u64 as u64,
                         )
                     }
                 }
@@ -184,12 +184,12 @@ impl TcpStream {
                     unsafe {
                         host::api::networking::tcp_connect(
                             6,
-                            ip.as_ptr(),
+                            ip.as_ptr() as u32,
                             port,
                             flow_info,
                             scope_id,
                             timeout_ms,
-                            &mut id as *mut u64,
+                            &mut id as *mut u64 as u64,
                         )
                     }
                 }
@@ -214,10 +214,10 @@ impl Write for TcpStream {
         let result = unsafe {
             host::api::networking::tcp_write_vectored(
                 self.id,
-                bufs.as_ptr() as *const u32,
-                bufs.len(),
+                bufs.as_ptr() as u32,
+                bufs.len() as u32,
                 self.write_timeout,
-                &mut nwritten_or_error_id as *mut u64,
+                &mut nwritten_or_error_id as *mut u64 as u64,
             )
         };
         if result == 0 {
@@ -230,7 +230,8 @@ impl Write for TcpStream {
 
     fn flush(&mut self) -> Result<()> {
         let mut error_id = 0;
-        match unsafe { host::api::networking::tcp_flush(self.id, &mut error_id as *mut u64) } {
+        match unsafe { host::api::networking::tcp_flush(self.id, &mut error_id as *mut u64 as u64) }
+        {
             0 => Ok(()),
             _ => {
                 let lunatic_error = LunaticError::from(error_id);
@@ -246,10 +247,10 @@ impl Read for TcpStream {
         let result = unsafe {
             host::api::networking::tcp_read(
                 self.id,
-                buf.as_mut_ptr(),
-                buf.len(),
+                buf.as_mut_ptr() as u32,
+                buf.len() as u32,
                 self.read_timeout,
-                &mut nread_or_error_id as *mut u64,
+                &mut nread_or_error_id as *mut u64 as u64,
             )
         };
         if result == 0 {

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -39,14 +39,14 @@ impl Drop for TcpStream {
     fn drop(&mut self) {
         // Only drop stream if it's not already consumed
         if unsafe { !*self.consumed.get() } {
-            unsafe { host::api::networking::drop_tcp_stream(self.id) };
+            host::api::networking::drop_tcp_stream(self.id);
         }
     }
 }
 
 impl Clone for TcpStream {
     fn clone(&self) -> Self {
-        let id = unsafe { host::api::networking::clone_tcp_stream(self.id) };
+        let id = host::api::networking::clone_tcp_stream(self.id);
         Self {
             id,
             read_timeout: self.read_timeout,
@@ -64,7 +64,7 @@ impl Serialize for TcpStream {
         // Mark process as consumed
         unsafe { *self.consumed.get() = true };
         // TODO: Timeout info is not serialized
-        let index = unsafe { host::api::message::push_tcp_stream(self.id) };
+        let index = host::api::message::push_tcp_stream(self.id);
         serializer.serialize_u64(index)
     }
 }
@@ -80,7 +80,7 @@ impl<'de> Visitor<'de> for TcpStreamVisitor {
     where
         E: de::Error,
     {
-        let id = unsafe { host::api::message::take_tcp_stream(index) };
+        let id = host::api::message::take_tcp_stream(index);
         Ok(TcpStream::from(id))
     }
 }
@@ -164,34 +164,30 @@ impl TcpStream {
                 SocketAddr::V4(v4_addr) => {
                     let ip = v4_addr.ip().octets();
                     let port = v4_addr.port() as u32;
-                    unsafe {
-                        host::api::networking::tcp_connect(
-                            4,
-                            ip.as_ptr() as u32,
-                            port,
-                            0,
-                            0,
-                            timeout_ms,
-                            &mut id as *mut u64 as u64,
-                        )
-                    }
+                    host::api::networking::tcp_connect(
+                        4,
+                        ip.as_ptr() as u32,
+                        port,
+                        0,
+                        0,
+                        timeout_ms,
+                        &mut id as *mut u64 as u64,
+                    )
                 }
                 SocketAddr::V6(v6_addr) => {
                     let ip = v6_addr.ip().octets();
                     let port = v6_addr.port() as u32;
                     let flow_info = v6_addr.flowinfo();
                     let scope_id = v6_addr.scope_id();
-                    unsafe {
-                        host::api::networking::tcp_connect(
-                            6,
-                            ip.as_ptr() as u32,
-                            port,
-                            flow_info,
-                            scope_id,
-                            timeout_ms,
-                            &mut id as *mut u64 as u64,
-                        )
-                    }
+                    host::api::networking::tcp_connect(
+                        6,
+                        ip.as_ptr() as u32,
+                        port,
+                        flow_info,
+                        scope_id,
+                        timeout_ms,
+                        &mut id as *mut u64 as u64,
+                    )
                 }
             };
             if result == 0 {
@@ -211,15 +207,13 @@ impl Write for TcpStream {
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
         let mut nwritten_or_error_id: u64 = 0;
-        let result = unsafe {
-            host::api::networking::tcp_write_vectored(
-                self.id,
-                bufs.as_ptr() as u32,
-                bufs.len() as u32,
-                self.write_timeout,
-                &mut nwritten_or_error_id as *mut u64 as u64,
-            )
-        };
+        let result = host::api::networking::tcp_write_vectored(
+            self.id,
+            bufs.as_ptr() as u32,
+            bufs.len() as u32,
+            self.write_timeout,
+            &mut nwritten_or_error_id as *mut u64 as u64,
+        );
         if result == 0 {
             Ok(nwritten_or_error_id as usize)
         } else {
@@ -230,8 +224,7 @@ impl Write for TcpStream {
 
     fn flush(&mut self) -> Result<()> {
         let mut error_id = 0;
-        match unsafe { host::api::networking::tcp_flush(self.id, &mut error_id as *mut u64 as u64) }
-        {
+        match host::api::networking::tcp_flush(self.id, &mut error_id as *mut u64 as u64) {
             0 => Ok(()),
             _ => {
                 let lunatic_error = LunaticError::from(error_id);
@@ -244,15 +237,13 @@ impl Write for TcpStream {
 impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         let mut nread_or_error_id: u64 = 0;
-        let result = unsafe {
-            host::api::networking::tcp_read(
-                self.id,
-                buf.as_mut_ptr() as u32,
-                buf.len() as u32,
-                self.read_timeout,
-                &mut nread_or_error_id as *mut u64 as u64,
-            )
-        };
+        let result = host::api::networking::tcp_read(
+            self.id,
+            buf.as_mut_ptr() as u32,
+            buf.len() as u32,
+            self.read_timeout,
+            &mut nread_or_error_id as *mut u64 as u64,
+        );
         if result == 0 {
             Ok(nread_or_error_id as usize)
         } else {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -37,11 +37,11 @@ impl UdpSocket {
                     unsafe {
                         host::api::networking::udp_bind(
                             4,
-                            ip.as_ptr(),
+                            ip.as_ptr() as u32,
                             port,
                             0,
                             0,
-                            &mut id as *mut u64,
+                            &mut id as *mut u64 as u64,
                         )
                     }
                 }
@@ -53,11 +53,11 @@ impl UdpSocket {
                     unsafe {
                         host::api::networking::tcp_bind(
                             6,
-                            ip.as_ptr(),
+                            ip.as_ptr() as u32,
                             port,
                             flow_info,
                             scope_id,
-                            &mut id as *mut u64,
+                            &mut id as *mut u64 as u64,
                         )
                     }
                 }
@@ -75,7 +75,10 @@ impl UdpSocket {
     pub fn local_addr(&self) -> Result<SocketAddr> {
         let mut dns_iter_or_error_id = 0;
         let result = unsafe {
-            host::api::networking::udp_local_addr(self.id, &mut dns_iter_or_error_id as *mut u64)
+            host::api::networking::udp_local_addr(
+                self.id,
+                &mut dns_iter_or_error_id as *mut u64 as u64,
+            )
         };
         if result == 0 {
             let mut dns_iter = SocketAddrIterator::from(dns_iter_or_error_id);

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -11,7 +11,7 @@ pub struct UdpSocket {
 
 impl Drop for UdpSocket {
     fn drop(&mut self) {
-        unsafe { host::api::networking::drop_udp_socket(self.id) };
+        host::api::networking::drop_udp_socket(self.id);
     }
 }
 
@@ -34,32 +34,28 @@ impl UdpSocket {
                 SocketAddr::V4(v4_addr) => {
                     let ip = v4_addr.ip().octets();
                     let port = v4_addr.port() as u32;
-                    unsafe {
-                        host::api::networking::udp_bind(
-                            4,
-                            ip.as_ptr() as u32,
-                            port,
-                            0,
-                            0,
-                            &mut id as *mut u64 as u64,
-                        )
-                    }
+                    host::api::networking::udp_bind(
+                        4,
+                        ip.as_ptr() as u32,
+                        port,
+                        0,
+                        0,
+                        &mut id as *mut u64 as u64,
+                    )
                 }
                 SocketAddr::V6(v6_addr) => {
                     let ip = v6_addr.ip().octets();
                     let port = v6_addr.port() as u32;
                     let flow_info = v6_addr.flowinfo();
                     let scope_id = v6_addr.scope_id();
-                    unsafe {
-                        host::api::networking::tcp_bind(
-                            6,
-                            ip.as_ptr() as u32,
-                            port,
-                            flow_info,
-                            scope_id,
-                            &mut id as *mut u64 as u64,
-                        )
-                    }
+                    host::api::networking::tcp_bind(
+                        6,
+                        ip.as_ptr() as u32,
+                        port,
+                        flow_info,
+                        scope_id,
+                        &mut id as *mut u64 as u64,
+                    )
                 }
             };
             if result == 0 {
@@ -74,12 +70,10 @@ impl UdpSocket {
     /// This can be useful, for example, to identify when binding to port 0 which port was assigned by the OS.
     pub fn local_addr(&self) -> Result<SocketAddr> {
         let mut dns_iter_or_error_id = 0;
-        let result = unsafe {
-            host::api::networking::udp_local_addr(
-                self.id,
-                &mut dns_iter_or_error_id as *mut u64 as u64,
-            )
-        };
+        let result = host::api::networking::udp_local_addr(
+            self.id,
+            &mut dns_iter_or_error_id as *mut u64 as u64,
+        );
         if result == 0 {
             let mut dns_iter = SocketAddrIterator::from(dns_iter_or_error_id);
             let addr = dns_iter.next().expect("must contain one element");

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -39,7 +39,7 @@ impl<P: 'static, S> Drop for Protocol<P, S> {
                 std::any::type_name::<P>()
             );
         }
-        unsafe { host::api::process::drop_process(self.id) };
+        host::api::process::drop_process(self.id);
     }
 }
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -160,13 +160,13 @@ pub struct MessageRw {}
 
 impl std::io::Read for MessageRw {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        Ok(unsafe { message::read_data(buf.as_mut_ptr() as u32, buf.len() as u32) as usize })
+        Ok(message::read_data(buf.as_mut_ptr() as u32, buf.len() as u32) as usize)
     }
 }
 
 impl std::io::Write for MessageRw {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        Ok(unsafe { message::write_data(buf.as_ptr() as u32, buf.len() as u32) as usize })
+        Ok(message::write_data(buf.as_ptr() as u32, buf.len() as u32) as usize)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -160,13 +160,13 @@ pub struct MessageRw {}
 
 impl std::io::Read for MessageRw {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        Ok(unsafe { message::read_data(buf.as_mut_ptr(), buf.len()) })
+        Ok(unsafe { message::read_data(buf.as_mut_ptr() as u32, buf.len() as u32) as usize })
     }
 }
 
 impl std::io::Write for MessageRw {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        Ok(unsafe { message::write_data(buf.as_ptr(), buf.len()) })
+        Ok(unsafe { message::write_data(buf.as_ptr() as u32, buf.len() as u32) as usize })
     }
 
     fn flush(&mut self) -> std::io::Result<()> {

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -61,7 +61,7 @@ where
 
     fn init(_: ProcessRef<Self>, arg: T::Arg) -> Self::State {
         // Supervisor shouldn't die if the children die
-        unsafe { host::api::process::die_when_link_dies(0) };
+        host::api::process::die_when_link_dies(0);
 
         let mut config = SupervisorConfig::default();
         <T as Supervisor>::init(&mut config, arg);

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -11,6 +11,6 @@ impl TimerRef {
 
     /// Cancel the timer, blocking until the timer is canceled.
     pub fn cancel(self) -> bool {
-        unsafe { host::api::timer::cancel_timer(self.0) == 1 }
+        host::api::timer::cancel_timer(self.0) == 1
     }
 }

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -51,7 +51,9 @@ fn mailbox_timeout(m: Mailbox<i32>) {
 
 #[test]
 fn recursive_count(mailbox: Mailbox<i32>) {
-    Process::spawn_link((mailbox.this(), 1000), recursive_count_sub);
+    let mut config = ProcessConfig::new();
+    config.set_can_spawn_processes(true);
+    Process::spawn_link_config(&config, (mailbox.this(), 1000), recursive_count_sub);
     assert_eq!(500500, mailbox.receive());
 }
 

--- a/tests/task.rs
+++ b/tests/task.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use lunatic::{sleep, spawn_link};
+use lunatic::{sleep, spawn_link, ProcessConfig};
 use lunatic_test::test;
 
 #[test]
@@ -25,7 +25,9 @@ fn result_must_be_called() {
 
 #[test]
 fn recursive_count() {
-    let task = spawn_link!(@task |n = 1_000| recursive_count_sub(n));
+    let mut config = ProcessConfig::new();
+    config.set_can_spawn_processes(true);
+    let task = spawn_link!(@task &config, |n = 1_000| recursive_count_sub(n));
     assert_eq!(500500, task.result());
 }
 

--- a/wit/lunatic_error.wit
+++ b/wit/lunatic_error.wit
@@ -1,0 +1,3 @@
+string-size : func(caller: u64) -> u32
+to-string   : func(error-id: u64, error-str: u32)
+drop        : func(error-id: u64)

--- a/wit/lunatic_message.wit
+++ b/wit/lunatic_message.wit
@@ -1,0 +1,13 @@
+create-data              : func(tag: s64, capacity: u64)
+write-data               : func(data: u32, data-len: u32) -> u32
+read-data                : func(data: u32, data-len: u32) -> u32
+seek-data                : func(position: u64)
+get-tag                  : func() -> s64
+data-size                : func() -> u64
+push-process             : func(process-id: u64) -> u64
+take-process             : func(index: u64) -> u64
+push-tcp-stream          : func(tcp-stream-id: u64) -> u64
+take-tcp-stream          : func(index: u64) -> u64
+send                     : func(process-id: u64)
+send-receive-skip-search : func(process-id: u64, timeout: u32) -> u32
+receive                  : func(tag: u32, tag-len: u32, timeout: u32) -> u32

--- a/wit/lunatic_networking.wit
+++ b/wit/lunatic_networking.wit
@@ -1,0 +1,62 @@
+resolve: func(
+  name-str: u32, 
+  name-str-len: u32, 
+  timeout: u32, 
+  id: u64)
+  -> u32
+drop-dns-iterator: func(dns-iter-id: u64)
+resolve-next: func(
+  dns-iter-id: u64,
+  addr-type: u32,
+  addr: u32,
+  port: u16,
+  flow-info: u32,
+  scope-id: u32,
+) -> u32
+tcp-bind: func(
+  addr-type: u32,
+  addr: u32,
+  port: u32,
+  flow-info: u32,
+  scope-id: u32,
+  id: u64,
+) -> u32
+udp-bind: func(
+  addr-type: u32,
+  addr: u32,
+  port: u32,
+  flow-info: u32,
+  scope-id: u32,
+  id: u64,
+) -> u32
+drop-tcp-listener: func(tcp-listener-id: u64)
+drop-udp-socket: func(udp-socket-id: u64)
+tcp-local-addr: func(tcp-listener-id: u64, addr-dns-iter: u64) -> u32
+udp-local-addr: func(udp-socket-id: u64, addr-dns-iter: u64) -> u32
+tcp-accept: func(listener-id: u64, id: u64, peer-dns-iter: u64) -> u32
+tcp-connect: func(
+  addr-type: u32,
+  addr: u32,
+  port: u32,
+  flow-info: u32,
+  scope-id: u32,
+  timeout: u32,
+  id: u64,
+) -> u32
+drop-tcp-stream: func(tcp-stream-id: u64)
+clone-tcp-stream: func(tcp-stream-id: u64) -> u64
+tcp-write-vectored: func(
+  tcp-stream-id: u64,
+  ciovec-array: u32,
+  ciovec-array-len: u32,
+  timeout: u32,
+  opaque: u64,
+) -> u32
+tcp-read: func(
+  tcp-stream-id: u64,
+  buffer: u32,
+  buffer-len: u32,
+  timeout: u32,
+  opaque: u64,
+) -> u32
+tcp-flush: func(tcp-stream-id: u64, error-id: u64) -> u32

--- a/wit/lunatic_process.wit
+++ b/wit/lunatic_process.wit
@@ -1,0 +1,33 @@
+compile-module: func(data: u32, data-len: u32, id: u32) -> s32
+drop-module: func(config-id: u64)
+create-config: func() -> u64
+drop-config: func(config-id: u64)
+config-set-max-memory: func(config-id: u64, max-memory: u64)
+config-get-max-memory: func(config-id: u64) -> u64
+config-set-max-fuel: func(config-id: u64, max-fuel: u64)
+config-get-max-fuel: func(config-id: u64) -> u64
+config-can-compile-modules: func(config-id: u64) -> u32
+config-set-can-compile-modules: func(config-id: u64, can: u32)
+config-can-create-configs: func(config-id: u64) -> u32
+config-set-can-create-configs: func(config-id: u64, can: u32)
+config-can-spawn-processes: func(config-id: u64) -> u32
+config-set-can-spawn-processes: func(config-id: u64, can: u32)
+spawn: func(
+  link: s64,
+  config-id: s64,
+  module-id: s64,
+  function: u32,
+  function-len: u32,
+  params: u32,
+  params-len: u32,
+  id: u32,
+) -> u32
+drop-process: func(process-id: u64)
+clone-process: func(process-id: u64) -> u64
+sleep-ms: func(millis: u64)
+die-when-link-dies: func(trap: u32)
+this: func() -> u64
+id: func(process-id: u64, uuid: u32)
+link: func(tag: s64, process-id: u64)
+unlink: func(process-id: u64)
+kill: func(process-id: u64)

--- a/wit/lunatic_registry.wit
+++ b/wit/lunatic_registry.wit
@@ -1,0 +1,3 @@
+put: func(name: u32, name-len: u32, process-id: u64)
+get: func(name: u32, name-len: u32, process-id: u32) -> u32
+remove: func(name: u32, name-len: u32)

--- a/wit/lunatic_timer.wit
+++ b/wit/lunatic_timer.wit
@@ -1,0 +1,2 @@
+send-after   : func(process-id: u64, duration: u64) -> u64
+cancel-timer : func(timer-id: u64) -> u32

--- a/wit/lunatic_version.wit
+++ b/wit/lunatic_version.wit
@@ -1,0 +1,3 @@
+major: func() -> u32
+minor: func() -> u32
+patch: func() -> u32

--- a/wit/lunatic_wasi.wit
+++ b/wit/lunatic_wasi.wit
@@ -1,0 +1,9 @@
+config-add-environment-variable: func(
+  config-id: u64,
+  key: u32,
+  key-len: u32,
+  value: u32,
+  value-len: u32,
+)
+config-add-command-line-argument: func(config-id: u64, key: u32, key-len: u32)
+config-preopen-dir: func(config-id: u64, key: u32, key-len: u32)


### PR DESCRIPTION
Use WIT definition for importing host functions as per https://github.com/lunatic-solutions/lunatic/issues/86#issue-1110599871

This is an initial attempt at using [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen) crate to generate wasm function imports. Currently, I only have experimented with using wit-bindgen on the rust-lib and it has passed all the unit tests.

There are several design changes/sacrifice that was made to the VM and rust-lib to get this to work:
- In ```.wit``` files, identifiers are strictly in kebab-case. In order to comply with wit-bindgen, I had to rename the module name and the function name.
- Using wit-codegen, the imported functions are not marked as unsafe. I removed all the unsafe blocks for the host function calls since the compiler is giving me ```unnecessary unsafe block``` warning. I am unsure if there are negative implications of removing them that I am not aware of.

I think we might be cautious about depending on ```.wit``` files at this time because according to the readme of wit-bindgen, the library is not yet stable and the ```.wit``` format does not have a formal definition yet (https://github.com/bytecodealliance/wit-bindgen/issues/251#issuecomment-1159042486). 

Those are some of my thoughts and I would love some feedback. 