### PR TITLE
Feature net::UdpSocket connect, send+to, recv+from, etc.

### DIFF
--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -83,6 +83,7 @@ pub mod networking {
             id: *mut u64,
         ) -> u32;
         pub fn udp_connect(
+            udp_socket_id: u64,
             addr_type: u32,
             addr: *const u8,
             port: u32,

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -143,7 +143,9 @@ pub mod networking {
             dns_iter_ptr: *mut u64,
         ) -> u32;
         pub fn set_udp_socket_ttl(udp_socket_id: u64, ttl: u32) -> ();
+        pub fn set_udp_socket_broadcast(udp_socket_id: u64, broadcast: u32) -> ();
         pub fn get_udp_socket_ttl(udp_socket_id: u64) -> u32;
+        pub fn get_udp_socket_broadcast(udp_socket_id: u64) -> i32;
         pub fn tcp_flush(tcp_stream_id: u64, error_id: *mut u64) -> u32;
     }
 }

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -146,6 +146,7 @@ pub mod networking {
         pub fn set_udp_socket_broadcast(udp_socket_id: u64, broadcast: u32);
         pub fn get_udp_socket_ttl(udp_socket_id: u64) -> u32;
         pub fn get_udp_socket_broadcast(udp_socket_id: u64) -> i32;
+        pub fn clone_udp_socket(udp_socket_id: u64) -> u64;
         pub fn tcp_flush(tcp_stream_id: u64, error_id: *mut u64) -> u32;
     }
 }

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -142,8 +142,8 @@ pub mod networking {
             opaque: *mut u64,
             dns_iter_ptr: *mut u64,
         ) -> u32;
-        pub fn set_udp_socket_ttl(udp_socket_id: u64, ttl: u32) -> ();
-        pub fn set_udp_socket_broadcast(udp_socket_id: u64, broadcast: u32) -> ();
+        pub fn set_udp_socket_ttl(udp_socket_id: u64, ttl: u32);
+        pub fn set_udp_socket_broadcast(udp_socket_id: u64, broadcast: u32);
         pub fn get_udp_socket_ttl(udp_socket_id: u64) -> u32;
         pub fn get_udp_socket_broadcast(udp_socket_id: u64) -> i32;
         pub fn tcp_flush(tcp_stream_id: u64, error_id: *mut u64) -> u32;

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -82,6 +82,15 @@ pub mod networking {
             timeout: u32,
             id: *mut u64,
         ) -> u32;
+        pub fn udp_connect(
+            addr_type: u32,
+            addr: *const u8,
+            port: u32,
+            flow_info: u32,
+            scope_id: u32,
+            timeout: u32,
+            id: *mut u64,
+        ) -> u32;
         pub fn drop_tcp_stream(tcp_stream_id: u64);
         pub fn clone_tcp_stream(tcp_stream_id: u64) -> u64;
         pub fn tcp_write_vectored(

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -142,6 +142,8 @@ pub mod networking {
             opaque: *mut u64,
             dns_iter_ptr: *mut u64,
         ) -> u32;
+        pub fn set_udp_socket_ttl(udp_socket_id: u64, ttl: u32) -> ();
+        pub fn get_udp_socket_ttl(udp_socket_id: u64) -> u32;
         pub fn tcp_flush(tcp_stream_id: u64, error_id: *mut u64) -> u32;
     }
 }

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -108,6 +108,20 @@ pub mod networking {
             timeout: u32,
             opaque: *mut u64,
         ) -> u32;
+        pub fn udp_send(
+            udp_socket_id: u64,
+            buffer: *mut u8,
+            buffer_len: usize,
+            timeout: u32,
+            opaque: *mut u64,
+        ) -> u32;
+        pub fn udp_receive(
+            udp_socket_id: u64,
+            buffer: *mut u8,
+            buffer_len: usize,
+            timeout: u32,
+            opaque: *mut u64,
+        ) -> u32;
         pub fn tcp_flush(tcp_stream_id: u64, error_id: *mut u64) -> u32;
     }
 }

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -122,6 +122,14 @@ pub mod networking {
             timeout: u32,
             opaque: *mut u64,
         ) -> u32;
+        pub fn udp_receive_from(
+            udp_socket_id: u64,
+            buffer: *mut u8,
+            buffer_len: usize,
+            timeout: u32,
+            opaque: *mut u64,
+            dns_iter_ptr: *mut u64,
+        ) -> u32;
         pub fn tcp_flush(tcp_stream_id: u64, error_id: *mut u64) -> u32;
     }
 }

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -110,7 +110,7 @@ pub mod networking {
         ) -> u32;
         pub fn udp_send(
             udp_socket_id: u64,
-            buffer: *mut u8,
+            buffer: *const u8,
             buffer_len: usize,
             timeout: u32,
             opaque: *mut u64,

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -115,6 +115,18 @@ pub mod networking {
             timeout: u32,
             opaque: *mut u64,
         ) -> u32;
+        pub fn udp_send_to(
+            udp_socket_id: u64,
+            buffer: *const u8,
+            buffer_len: usize,
+            addr_type: u32,
+            addr: *const u8,
+            port: u32,
+            flow_info: u32,
+            scope_id: u32,
+            timeout: u32,
+            opaque: *mut u64,
+        ) -> u32;
         pub fn udp_receive(
             udp_socket_id: u64,
             buffer: *mut u8,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -382,9 +382,7 @@ impl UdpSocket {
     /// ```
     pub fn set_ttl(&self, ttl: u32) -> Result<()> {
         // no result for this? it's () ?
-        unsafe {
-            host::api::networking::set_udp_socket_ttl(self.id, ttl)
-        };
+        unsafe { host::api::networking::set_udp_socket_ttl(self.id, ttl) };
         // there is no error for this?
         Ok(())
     }
@@ -403,9 +401,7 @@ impl UdpSocket {
     /// ```
     pub fn ttl(&self) -> Result<u32> {
         // there is no error for this?
-        let result = unsafe {
-            host::api::networking::get_udp_socket_ttl(self.id)
-        };
+        let result = unsafe { host::api::networking::get_udp_socket_ttl(self.id) };
         Ok(result)
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -430,7 +430,30 @@ impl UdpSocket {
     pub fn set_ttl(&self, ttl: u32) -> Result<()> {
         // no result for this? it's () ?
         unsafe { host::api::networking::set_udp_socket_ttl(self.id, ttl) };
-        // there is no error for this?
+        // there is no error for this
+        Ok(())
+    }
+    /// Sets the value of the `SO_BROADCAST` option for this socket.
+    ///
+    /// When enabled, this socket is allowed to send packets to a broadcast
+    /// address.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use lunatic::net::UdpSocket;
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
+    /// socket.set_broadcast(false).expect("set_broadcast call failed");
+    /// ```
+    pub fn set_broadcast(&self, broadcast: bool) -> Result<()> {
+        // no result for this? it's () ?
+        let api_broadcast = match broadcast {
+            true => 1,
+            false => 0,
+        };
+        unsafe { host::api::networking::set_udp_socket_broadcast(self.id, api_broadcast) };
+        // there is no error for this
         Ok(())
     }
     /// Gets the value of the `IP_TTL` option for this socket.
@@ -450,5 +473,25 @@ impl UdpSocket {
         // there is no error for this?
         let result = unsafe { host::api::networking::get_udp_socket_ttl(self.id) };
         Ok(result)
+    }
+    /// Gets the value of the `SO_BROADCAST` option for this socket.
+    ///
+    /// For more information about this option, see [`UdpSocket::set_broadcast`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use lunatic::net::UdpSocket;
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
+    /// socket.set_broadcast(false).expect("set_broadcast call failed");
+    /// assert_eq!(socket.broadcast().unwrap(), false);
+    /// ```
+    pub fn broadcast(&self) -> Result<bool> {
+        let result = unsafe { host::api::networking::get_udp_socket_broadcast(self.id) };
+        match result {
+            0 => Ok(false),
+            _ => Ok(true),
+        }
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -135,7 +135,7 @@ impl UdpSocket {
     where
         A: super::ToSocketAddrs,
     {
-        let mut id = self.id;
+        let mut id = 0;
         for addr in addr.to_socket_addrs()? {
             let result = match addr {
                 SocketAddr::V4(v4_addr) => {
@@ -143,6 +143,7 @@ impl UdpSocket {
                     let port = v4_addr.port() as u32;
                     unsafe {
                         host::api::networking::udp_connect(
+                            self.id,
                             4,
                             ip.as_ptr(),
                             port,
@@ -160,6 +161,7 @@ impl UdpSocket {
                     let scope_id = v6_addr.scope_id();
                     unsafe {
                         host::api::networking::udp_connect(
+                            self.id,
                             6,
                             ip.as_ptr(),
                             port,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -131,7 +131,7 @@ impl UdpSocket {
     /// function of a UDP socket is not a useful thing to do: The OS will be
     /// unable to determine whether something is listening on the remote
     /// address without the application sending data.    
-    pub fn connect<A>(&mut self, addr: A) -> Result<()>
+    pub fn connect<A>(&self, addr: A) -> Result<()>
     where
         A: super::ToSocketAddrs,
     {
@@ -174,7 +174,7 @@ impl UdpSocket {
                 }
             };
             if result == 0 {
-                self.id = id;
+                //self.id = id;
                 return Ok(());
             }
         }
@@ -195,7 +195,7 @@ impl UdpSocket {
     /// socket.connect("127.0.0.1:8080").expect("connect function failed");
     /// socket.send(&[0, 1, 2]).expect("couldn't send message");
     /// ```
-    pub fn send(&mut self, buf: &[u8]) -> Result<usize> {
+    pub fn send(&self, buf: &[u8]) -> Result<usize> {
         let mut nsend_or_error_id: u64 = 0;
         let result = unsafe {
             host::api::networking::udp_send(
@@ -236,7 +236,7 @@ impl UdpSocket {
     ///     Err(e) => println!("recv function failed: {e:?}"),
     /// }
     /// ```
-    pub fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {
+    pub fn recv(&self, buf: &mut [u8]) -> Result<usize> {
         let mut nrecv_or_error_id: u64 = 0;
         let result = unsafe {
             host::api::networking::udp_receive(

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -233,7 +233,7 @@ impl UdpSocket {
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// socket.send_to(&[0; 10], "127.0.0.1:4242").expect("couldn't send data");
     /// ```
-    pub fn send_to<A>(&self, addr: A, buf: &[u8]) -> Result<usize>
+    pub fn send_to<A>(&self, buf: &[u8], addr: A) -> Result<usize>
     where
         A: super::ToSocketAddrs,
     {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -541,4 +541,27 @@ impl UdpSocket {
             _ => Ok(true),
         }
     }
+    /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// The returned `UdpSocket` is a reference to the same socket that this
+    /// object references. Both handles will read and write the same port, and
+    /// options set on one socket will be propagated to the other.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use lunatic::net::UdpSocket;
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
+    /// let socket_clone = socket.try_clone().expect("couldn't clone the socket");
+    /// ```
+    pub fn try_clone(&self) -> Result<UdpSocket> {
+        let result = unsafe { host::api::networking::clone_udp_socket(self.id) };
+        Ok(Self {
+            id: result,
+            read_timeout: 0,
+            write_timeout: 0,
+            consumed: UnsafeCell::new(false),
+        })
+    }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -8,6 +8,53 @@ use std::{
 use super::SocketAddrIterator;
 use crate::{error::LunaticError, host};
 
+/// A UDP socket.
+///
+/// After creating a `UdpSocket` by [`bind`]ing it to a socket address, data can be
+/// [sent to] and [received from] any other socket address.
+///
+/// Although UDP is a connectionless protocol, this implementation provides an interface
+/// to set an address where data should be sent and received from. After setting a remote
+/// address with [`connect`], data can be sent to and received from that address with
+/// [`send`] and [`recv`].
+///
+/// As stated in the User Datagram Protocol's specification in [IETF RFC 768], UDP is
+/// an unordered, unreliable protocol; refer to [`TcpListener`] and [`TcpStream`] for TCP
+/// primitives.
+///
+/// [`bind`]: UdpSocket::bind
+/// [`connect`]: UdpSocket::connect
+/// [IETF RFC 768]: https://tools.ietf.org/html/rfc768
+/// [`recv`]: UdpSocket::recv
+/// [received from]: UdpSocket::recv_from
+/// [`send`]: UdpSocket::send
+/// [sent to]: UdpSocket::send_to
+/// [`TcpListener`]: crate::net::TcpListener
+/// [`TcpStream`]: crate::net::TcpStream
+///
+/// # Examples
+///
+/// ```no_run
+/// use lunatic::net::UdpSocket;
+///
+/// #[lunatic::main]
+/// fn main(_: Mailbox<()>) -> std::io::Result<()> {
+///     {
+///         let socket = UdpSocket::bind("127.0.0.1:34254")?;
+///
+///         // Receives a single datagram message on the socket. If `buf` is too small to hold
+///         // the message, it will be cut off.
+///         let mut buf = [0; 10];
+///         let (amt, src) = socket.recv_from(&mut buf)?;
+///
+///         // Redeclare `buf` as slice of the received data and send reverse data back to origin.
+///         let buf = &mut buf[..amt];
+///         buf.reverse();
+///         socket.send_to(buf, &src)?;
+///     } // the socket is closed here
+///     Ok(())
+/// }
+/// ```
 #[derive(Debug)]
 pub struct UdpSocket {
     id: u64,
@@ -263,14 +310,14 @@ impl UdpSocket {
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes written.
     ///
-    /// Address type can be any implementor of [`ToSocketAddrs`] trait. See its
+    /// Address type can be any implementor of [`super::ToSocketAddrs`] trait. See its
     /// documentation for concrete examples.
     ///
     /// It is possible for `addr` to yield multiple addresses, but `send_to`
     /// will only send data to the first address yielded by `addr`.
     ///
     /// This will return an error when the IP version of the local socket
-    /// does not match that returned from [`ToSocketAddrs`].
+    /// does not match that returned from [`super::ToSocketAddrs`].
     ///
     /// # Examples
     ///

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -131,7 +131,7 @@ impl UdpSocket {
     /// function of a UDP socket is not a useful thing to do: The OS will be
     /// unable to determine whether something is listening on the remote
     /// address without the application sending data.    
-    pub fn connect<A>(&self, addr: A) -> Result<()>
+    pub fn connect<A>(&mut self, addr: A) -> Result<()>
     where
         A: super::ToSocketAddrs,
     {
@@ -174,6 +174,7 @@ impl UdpSocket {
                 }
             };
             if result == 0 {
+                self.id = id;
                 return Ok(());
             }
         }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -287,7 +287,7 @@ impl UdpSocket {
         };
         if result == 0 {
             let mut dns_iter = SocketAddrIterator::from(dns_iter_id);
-            let peer = dns_iter.next().expect("must contain one element"); 
+            let peer = dns_iter.next().expect("must contain one element");
             Ok((nrecv_or_error_id as usize, peer))
         } else {
             let lunatic_error = LunaticError::from(nrecv_or_error_id);

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,5 +1,8 @@
-use std::io::{Error, ErrorKind, Result};
-use std::net::SocketAddr;
+use std::{
+    cell::UnsafeCell,
+    io::{Error, ErrorKind, Result},
+    net::SocketAddr,
+};
 
 use super::SocketAddrIterator;
 use crate::{error::LunaticError, host};
@@ -7,11 +10,22 @@ use crate::{error::LunaticError, host};
 #[derive(Debug)]
 pub struct UdpSocket {
     id: u64,
+
+    // Issue - https://github.com/lunatic-solutions/lunatic/issues/95
+    // read_timeout: u32,  // ms
+    // write_timeout: u32, // ms
+
+    // If the UDP Socket is serialized it will be removed from our resources, so we can't call
+    // `drop_udp_socket()` anymore on it.
+    consumed: UnsafeCell<bool>,
 }
 
 impl Drop for UdpSocket {
     fn drop(&mut self) {
-        unsafe { host::api::networking::drop_udp_socket(self.id) };
+        // Only drop stream if it's not already consumed
+        if unsafe { !*self.consumed.get() } {
+            unsafe { host::api::networking::drop_udp_socket(self.id) };
+        }
     }
 }
 
@@ -51,7 +65,7 @@ impl UdpSocket {
                     let flow_info = v6_addr.flowinfo();
                     let scope_id = v6_addr.scope_id();
                     unsafe {
-                        host::api::networking::tcp_bind(
+                        host::api::networking::udp_bind(
                             6,
                             ip.as_ptr(),
                             port,
@@ -63,7 +77,10 @@ impl UdpSocket {
                 }
             };
             if result == 0 {
-                return Ok(Self { id });
+                return Ok(Self {
+                    id,
+                    consumed: UnsafeCell::new(false),
+                });
             }
         }
         let lunatic_error = LunaticError::from(id);
@@ -85,5 +102,80 @@ impl UdpSocket {
             let lunatic_error = LunaticError::from(dns_iter_or_error_id);
             Err(Error::new(ErrorKind::Other, lunatic_error))
         }
+    }
+    /// Connects this UDP socket to a remote address, allowing the `send` and
+    /// `recv` syscalls to be used to send data and also applies filters to only
+    /// receive data from the specified address.
+    ///
+    /// If `addr` yields multiple addresses, `connect` will be attempted with
+    /// each of the addresses until the underlying OS function returns no
+    /// error. Note that usually, a successful `connect` call does not specify
+    /// that there is a remote server listening on the port, rather, such an
+    /// error would only be detected after the first send. If the OS returns an
+    /// error for each of the specified addresses, the error returned from the
+    /// last connection attempt (the last address) is returned.
+    ///
+    /// # Examples
+    ///
+    /// Creates a UDP socket bound to `127.0.0.1:3400` and connect the socket to
+    /// `127.0.0.1:8080`:
+    ///
+    /// ```no_run
+    /// use lunatic::net::UdpSocket;
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:3400").expect("couldn't bind to address");
+    /// socket.connect("127.0.0.1:8080").expect("connect function failed");
+    /// ```
+    ///
+    /// Unlike in the TCP case, passing an array of addresses to the `connect`
+    /// function of a UDP socket is not a useful thing to do: The OS will be
+    /// unable to determine whether something is listening on the remote
+    /// address without the application sending data.    
+    pub fn connect<A>(&self, addr: A) -> Result<()>
+    where
+        A: super::ToSocketAddrs,
+    {
+        let mut id = self.id;
+        for addr in addr.to_socket_addrs()? {
+            let result = match addr {
+                SocketAddr::V4(v4_addr) => {
+                    let ip = v4_addr.ip().octets();
+                    let port = v4_addr.port() as u32;
+                    unsafe {
+                        host::api::networking::udp_connect(
+                            4,
+                            ip.as_ptr(),
+                            port,
+                            0,
+                            0,
+                            0, // timeout_ms
+                            &mut id as *mut u64,
+                        )
+                    }
+                }
+                SocketAddr::V6(v6_addr) => {
+                    let ip = v6_addr.ip().octets();
+                    let port = v6_addr.port() as u32;
+                    let flow_info = v6_addr.flowinfo();
+                    let scope_id = v6_addr.scope_id();
+                    unsafe {
+                        host::api::networking::udp_connect(
+                            6,
+                            ip.as_ptr(),
+                            port,
+                            flow_info,
+                            scope_id,
+                            0, // timeout_ms
+                            &mut id as *mut u64,
+                        )
+                    }
+                }
+            };
+            if result == 0 {
+                return Ok(());
+            }
+        }
+        let lunatic_error = LunaticError::from(id);
+        Err(Error::new(ErrorKind::Other, lunatic_error))
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -195,12 +195,12 @@ impl UdpSocket {
     /// socket.connect("127.0.0.1:8080").expect("connect function failed");
     /// socket.send(&[0, 1, 2]).expect("couldn't send message");
     /// ```
-    pub fn send(&mut self, buf: &mut [u8]) -> Result<usize> {
+    pub fn send(&mut self, buf: &[u8]) -> Result<usize> {
         let mut nsend_or_error_id: u64 = 0;
         let result = unsafe {
             host::api::networking::udp_send(
                 self.id,
-                buf.as_mut_ptr(),
+                buf.as_ptr(),
                 buf.len(),
                 0, // self.write_timeout ?
                 &mut nsend_or_error_id as *mut u64,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -243,7 +243,7 @@ impl UdpSocket {
                 self.id,
                 buf.as_mut_ptr(),
                 buf.len(),
-                0, // self.write_timeout ?
+                0, // self.read_timeout ?
                 &mut nrecv_or_error_id as *mut u64,
             )
         };

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -564,4 +564,12 @@ impl UdpSocket {
             consumed: UnsafeCell::new(false),
         })
     }
+    /// Dummy fn - This is just to make porting from std easier?
+    pub fn set_nonblocking(&self, _: bool) -> Result<()> {
+        Ok(())
+    }
+    /// Dummy fn - This is just to make porting from std easier?
+    pub fn take_error(&self) -> Result<Option<LunaticError>> {
+        Ok(None)
+    }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -367,4 +367,45 @@ impl UdpSocket {
             Err(Error::new(ErrorKind::Other, lunatic_error))
         }
     }
+    /// Sets the value for the `IP_TTL` option on this socket.
+    ///
+    /// This value sets the time-to-live field that is used in every packet sent
+    /// from this socket.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use lunatic::net::UdpSocket;
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
+    /// socket.set_ttl(42).expect("set_ttl call failed");
+    /// ```
+    pub fn set_ttl(&self, ttl: u32) -> Result<()> {
+        // no result for this? it's () ?
+        unsafe {
+            host::api::networking::set_udp_socket_ttl(self.id, ttl)
+        };
+        // there is no error for this?
+        Ok(())
+    }
+    /// Gets the value of the `IP_TTL` option for this socket.
+    ///
+    /// For more information about this option, see [`UdpSocket::set_ttl`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use lunatic::net::UdpSocket;
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
+    /// socket.set_ttl(42).expect("set_ttl call failed");
+    /// assert_eq!(socket.ttl().unwrap(), 42);
+    /// ```
+    pub fn ttl(&self) -> Result<u32> {
+        // there is no error for this?
+        let result = unsafe {
+            host::api::networking::get_udp_socket_ttl(self.id)
+        };
+        Ok(result)
+    }
 }

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -37,3 +37,13 @@ fn udp_ping_recv_from_send_to_main() {
     assert_eq!(addr_in, sender_addr);
     assert_eq!(buf, "P2NG".as_bytes());
 }
+
+#[test]
+fn udp_ttl_setter_getter() {
+    let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    // set_ttl has no error
+    sender.set_ttl(42).unwrap();
+    let cur_ttl = sender.ttl().unwrap();
+
+    assert_eq!(cur_ttl, 42);
+}

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,0 +1,35 @@
+use lunatic::{net};
+use lunatic_test::test;
+
+#[test]
+fn udp_ping_connect_recv_send_main() {
+    let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let receiver = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let receiver_addr = receiver.local_addr().unwrap();
+    
+    sender.connect(receiver_addr).expect("couldn't connect");
+    sender.send("P1NG".as_bytes()).expect("couldn't send message");
+    
+    let mut buf = [0; 4];
+    let len_in = receiver.recv(&mut buf).unwrap();
+
+    assert_eq!(len_in, 4);
+    assert_eq!(buf, "P1NG".as_bytes());
+}
+
+#[test]
+fn udp_ping_recv_from_send_to_main() {
+    let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let sender_addr = sender.local_addr().unwrap();
+    let receiver = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let receiver_addr = receiver.local_addr().unwrap();
+    
+    sender.send_to("P2NG".as_bytes(), receiver_addr).expect("couldn't send message");
+    
+    let mut buf = [0; 4];
+    let (len_in, addr_in) = receiver.recv_from(&mut buf).unwrap();
+
+    assert_eq!(len_in, 4);
+    assert_eq!(addr_in, sender_addr);
+    assert_eq!(buf, "P2NG".as_bytes());
+}

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -41,9 +41,27 @@ fn udp_ping_recv_from_send_to_main() {
 #[test]
 fn udp_ttl_setter_getter() {
     let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
-    // set_ttl has no error
     sender.set_ttl(42).unwrap();
     let cur_ttl = sender.ttl().unwrap();
 
     assert_eq!(cur_ttl, 42);
+}
+
+#[test]
+fn udp_broadcast_setter_getter_true() {
+    let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    sender.set_broadcast(true).unwrap();
+    let cur_broadcast = sender.broadcast().unwrap();
+
+    assert_eq!(cur_broadcast, true);
+}
+
+#[test]
+fn udp_broadcast_setter_getter_false() {
+    let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    sender.set_broadcast(true).unwrap();
+    sender.set_broadcast(false).unwrap();
+    let cur_broadcast = sender.broadcast().unwrap();
+
+    assert_eq!(cur_broadcast, false);
 }

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,4 +1,4 @@
-use lunatic::{net};
+use lunatic::net;
 use lunatic_test::test;
 
 #[test]
@@ -6,10 +6,12 @@ fn udp_ping_connect_recv_send_main() {
     let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
     let receiver = net::UdpSocket::bind("127.0.0.1:0").unwrap();
     let receiver_addr = receiver.local_addr().unwrap();
-    
+
     sender.connect(receiver_addr).expect("couldn't connect");
-    sender.send("P1NG".as_bytes()).expect("couldn't send message");
-    
+    sender
+        .send("P1NG".as_bytes())
+        .expect("couldn't send message");
+
     let mut buf = [0; 4];
     let len_in = receiver.recv(&mut buf).unwrap();
 
@@ -23,9 +25,11 @@ fn udp_ping_recv_from_send_to_main() {
     let sender_addr = sender.local_addr().unwrap();
     let receiver = net::UdpSocket::bind("127.0.0.1:0").unwrap();
     let receiver_addr = receiver.local_addr().unwrap();
-    
-    sender.send_to("P2NG".as_bytes(), receiver_addr).expect("couldn't send message");
-    
+
+    sender
+        .send_to("P2NG".as_bytes(), receiver_addr)
+        .expect("couldn't send message");
+
     let mut buf = [0; 4];
     let (len_in, addr_in) = receiver.recv_from(&mut buf).unwrap();
 

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -39,6 +39,46 @@ fn udp_ping_recv_from_send_to_main() {
 }
 
 #[test]
+fn udp_ping_sender_clone() {
+    let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let sender2 = sender.try_clone().unwrap();
+
+    let receiver = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let receiver_addr = receiver.local_addr().unwrap();
+
+    sender2.connect(receiver_addr).expect("couldn't connect");
+    sender2
+        .send("P1NG".as_bytes())
+        .expect("couldn't send message");
+
+    let mut buf = [0; 4];
+    let len_in = receiver.recv(&mut buf).unwrap();
+
+    assert_eq!(len_in, 4);
+    assert_eq!(buf, "P1NG".as_bytes());
+}
+
+#[test]
+fn udp_ping_receiver_clone() {
+    let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+
+    let receiver = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let receiver2 = receiver.try_clone().unwrap();
+    let receiver_addr = receiver2.local_addr().unwrap();
+
+    sender.connect(receiver_addr).expect("couldn't connect");
+    sender
+        .send("P1NG".as_bytes())
+        .expect("couldn't send message");
+
+    let mut buf = [0; 4];
+    let len_in = receiver2.recv(&mut buf).unwrap();
+
+    assert_eq!(len_in, 4);
+    assert_eq!(buf, "P1NG".as_bytes());
+}
+
+#[test]
 fn udp_ttl_setter_getter() {
     let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
     sender.set_ttl(42).unwrap();


### PR DESCRIPTION
Working  on #17 

**Implements**
- [X] connect()
- [X] send(), send_to()
- [X] recv(), recv_from()
- [X] set_ttl(), ttl()
- [X] set_broadcast, broadcast()
- [X] set, get, use timeouts
- [X] dummy fn's set_nonblocking & take_error

**Notes**
- std UdpSocket connect has no connect timeout unlike lunatic host fn - as it's stateless unlike Tcp
- There does not seem to be peer_addr() host networking API call for connect()'ed UDP sockets ? should there be ?
- https://github.com/lunatic-solutions/lunatic/issues/110
- std::UdpSocket peer_addr : https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.peer_addr
- Multicast & Peek not in host networking API

**Moar Notes**
- UdpSocket IPv6 addr bind accidentally called tcp_bind :scream: :woman_facepalming: - fixed it :cold_sweat: :hot_face: 
- As previous consider in future to refactor for addr in addr.to_socket_addrs() like std net's each_addr