### PR TITLE
Block on process shutdown

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -297,8 +297,12 @@ fn starter<T>(
                         unsafe { std::mem::transmute(handler) };
                     handler(&mut state, sender);
                 }
-                Sendable::Shutdown => {
+                Sendable::Shutdown(sender) => {
+                    // Get tag out of message first
+                    let tag = unsafe { host::api::message::get_tag() };
+                    let tag = Tag::from(tag);
                     T::terminate(state);
+                    sender.tag_send(tag, ());
                     break;
                 }
             },
@@ -409,11 +413,33 @@ where
 {
     /// Shut down process
     pub fn shutdown(&self) {
+        self.shutdown_timeout(Duration::new(0, 0))
+            .expect("no timeout specified")
+    }
+
+    /// Shut down process with a timeout
+    pub fn shutdown_timeout(&self, duration: Duration) -> Result<(), ReceiveError> {
         // Create new message buffer.
-        unsafe { host::api::message::create_data(Tag::none().id(), 0) };
-        Bincode::encode(&Sendable::Shutdown).unwrap();
-        // Send the message
-        unsafe { host::api::message::send(self.process.id()) };
+        let tag = Tag::new();
+        unsafe { host::api::message::create_data(tag.id(), 0) };
+
+        // Create reference to self
+        let this: Process<()> = unsafe { Process::from_id(host::api::process::this()) };
+
+        Bincode::encode(&Sendable::Shutdown(this)).unwrap();
+
+        // Send the message and wait for response
+        // unsafe { host::api::message::send(self.process.id()) };
+        unsafe {
+            let result = host::api::message::send_receive_skip_search(
+                self.process.id(),
+                duration.as_millis() as u32,
+            );
+            if result == 9027 {
+                return Err(ReceiveError::Timeout);
+            }
+        };
+        Ok(())
     }
 }
 
@@ -426,7 +452,7 @@ enum Sendable {
     // The process type can't be carried over as a generic and is set here to `()`, but overwritten
     // at the time of returning with the correct type.
     Request(i32, Process<()>),
-    Shutdown,
+    Shutdown(Process<()>),
 }
 
 impl<M, S, T> Message<M, S> for ProcessRef<T>

--- a/src/process.rs
+++ b/src/process.rs
@@ -429,7 +429,6 @@ where
         Bincode::encode(&Sendable::Shutdown(this)).unwrap();
 
         // Send the message and wait for response
-        // unsafe { host::api::message::send(self.process.id()) };
         unsafe {
             let result = host::api::message::send_receive_skip_search(
                 self.process.id(),

--- a/tests/abstract_process.rs
+++ b/tests/abstract_process.rs
@@ -332,3 +332,26 @@ fn request_timeout() {
 
     assert!(response.is_err());
 }
+
+#[test]
+fn shutdown_timeout() {
+    struct A;
+
+    impl AbstractProcess for A {
+        type Arg = ();
+        type State = A;
+
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        fn terminate(_: Self::State) {
+            sleep(Duration::from_millis(25));
+        }
+    }
+
+    let a = A::start_link((), None);
+    let response = a.shutdown_timeout(Duration::from_millis(10));
+
+    assert!(response.is_err());
+}

--- a/tests/abstract_process.rs
+++ b/tests/abstract_process.rs
@@ -27,8 +27,6 @@ fn shutdown() {
 
     let a = A::start_link((), None);
     a.shutdown();
-
-    sleep(Duration::from_millis(100));
 }
 
 #[test]

--- a/tests/supervisor.rs
+++ b/tests/supervisor.rs
@@ -225,8 +225,6 @@ fn shutdown() {
 
     let sup = Sup::start((), None);
     sup.shutdown();
-
-    sleep(Duration::from_millis(100));
 }
 
 #[test]


### PR DESCRIPTION
PR for #39 
Made `shutdown` a blocking method and added method `shutdown_timeout`.

The implementation is similar to the `request` and the `request_timeout` methods.

- [x] Added unit test for `shutdown_timeout`
