### PR TITLE
Proof of Concept abstract_process Macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
 name = "lunatic-macros"
 version = "0.9.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
+
+[[package]]
 name = "criterion"
 version = "0.3.5"
 source = "git+https://github.com/bheisler/criterion.rs?branch=version-0.4#4b37d8a6cf80324c7707402e7f1f64ae6ef09d36"
@@ -169,6 +175,7 @@ dependencies = [
 name = "lunatic-macros"
 version = "0.9.0"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn",

--- a/lunatic-macros/Cargo.toml
+++ b/lunatic-macros/Cargo.toml
@@ -12,6 +12,7 @@ license = "Apache-2.0/MIT"
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0"
+convert_case = "0.5"
 
 [lib]
 proc-macro = true

--- a/lunatic-macros/Cargo.toml
+++ b/lunatic-macros/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0/MIT"
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0"
 
 [lib]
 proc-macro = true

--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -1,0 +1,224 @@
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::ImplItem::Method;
+
+pub(crate) fn render_abstract_process(impl_block: syn::ItemImpl) -> proc_macro::TokenStream {
+    let impl_attrs = impl_block.attrs;
+    let impl_ty = impl_block.self_ty;
+
+    // impl blocks for ProcessMessage and ProcessRequest
+    let mut impls: Vec<TokenStream> = vec![];
+    // AbstractProcess methods
+    let mut init_impl: Option<TokenStream> = None; // contains the State type
+    let mut terminate: Option<TokenStream> = None;
+    let mut handle_link_trapped: Option<TokenStream> = None;
+    // other items that will be left unchanged in the impl block
+    let mut skipped_items: Vec<TokenStream> = vec![];
+
+    for item in &impl_block.items {
+        match item {
+            Method(method) if method.has_tag("init") => init_impl = Some(render_init(method)),
+            Method(method) if method.has_tag("terminate") => {
+                terminate = Some(render_terminate(method));
+            }
+            Method(method) if method.has_tag("handle_link_trapped") => {
+                handle_link_trapped = Some(render_handle_link_trapped(method));
+            }
+            Method(method) if method.has_tag("process_message") => {
+                impls.push(render_process_message(method, &impl_ty));
+                skipped_items.push(quote! { #method });
+            }
+            Method(method) if method.has_tag("process_request") => {
+                impls.push(render_process_request(method, &impl_ty));
+                skipped_items.push(quote! { #method });
+            }
+            _ => {
+                skipped_items.push(quote! { #item });
+            }
+        }
+    }
+
+    // The extra clone will be optimized away by the compiler so we can write more concise code
+    let terminate_impl = terminate.clone().map(|_| {
+        quote! {
+            fn terminate(state: Self::State) {
+                state.terminate()
+            }
+        }
+    });
+
+    let handle_link_trapped_impl = handle_link_trapped.clone().map(|_| {
+        quote! {
+            fn handle_link_trapped(state: &mut Self::State, tag: Tag) {
+                state.handle_link_trapped(tag);
+            }
+        }
+    });
+
+    let init_impl = init_impl.unwrap_or(TokenStream::new());
+    let terminate = terminate.unwrap_or(TokenStream::new());
+    let handle_link_trapped = handle_link_trapped.unwrap_or(TokenStream::new());
+
+    let output = quote! {
+        #(#impl_attrs)*
+        impl #impl_ty {
+            #terminate
+            #handle_link_trapped
+            #(#skipped_items)*
+        }
+
+        impl lunatic::process::AbstractProcess for #impl_ty {
+            type State = #impl_ty;
+            #init_impl
+            #terminate_impl
+            #handle_link_trapped_impl
+        }
+
+        #(#impls)*
+    };
+    proc_macro::TokenStream::from(output)
+}
+
+fn render_init(item: &syn::ImplItemMethod) -> TokenStream {
+    let attrs = item.attrs.iter().filter(|attr| !attr.path.is_ident("init"));
+
+    let sig = &item.sig;
+    // ensure function name is init
+    let ident = if sig.ident != "init" {
+        quote_spanned! {
+            sig.ident.span() => compile_error!("Invalid function signature. Function name must be `init`.");
+        }
+    } else {
+        let ident = &sig.ident;
+        quote! { #ident }
+    };
+
+    let arg_type = if let syn::FnArg::Typed(arg) = sig.inputs.last().unwrap() {
+        &arg.ty
+    } else {
+        unreachable!()
+    };
+    let func_args = &sig.inputs;
+    let block = &item.block;
+
+    quote! {
+        type Arg = #arg_type;
+
+        #(#attrs)*
+        fn #ident(#func_args) -> Self::State #block
+    }
+    .into()
+}
+
+fn render_terminate(item: &syn::ImplItemMethod) -> TokenStream {
+    let sig = &item.sig;
+    // ensure function name is init
+    let ident = if sig.ident != "terminate" {
+        quote_spanned! {
+            sig.ident.span() => compile_error!("Invalid function signature. Function name must be `terminate`.");
+        }
+    } else {
+        let ident = &sig.ident;
+        quote! { #ident }
+    };
+
+    let self_arg = &sig.inputs;
+    let block = &item.block;
+
+    quote! {
+        fn #ident(#self_arg) #block
+    }
+    .into()
+}
+
+fn render_handle_link_trapped(item: &syn::ImplItemMethod) -> TokenStream {
+    let sig = &item.sig;
+    // ensure function name is init
+    let ident = if sig.ident != "handle_link_trapped" {
+        quote_spanned! {
+            sig.ident.span() => compile_error!("Invalid function signature. Function name must be `handle_link_trapped`.");
+        }
+    } else {
+        let ident = &sig.ident;
+        quote! { #ident }
+    };
+
+    let self_arg = &sig.inputs;
+    let block = &item.block;
+
+    quote! {
+        fn #ident(#self_arg) #block
+    }
+    .into()
+}
+
+fn render_process_message(item: &syn::ImplItemMethod, ident: &Box<syn::Type>) -> TokenStream {
+    let attrs = item
+        .attrs
+        .iter()
+        .filter(|attr| !attr.path.is_ident("process_message"));
+
+    let sig = &item.sig;
+    let fn_ident = &sig.ident;
+    let message_type = match sig.inputs.last().unwrap() {
+        syn::FnArg::Typed(arg) => {
+            let ty = &arg.ty;
+            quote! { #ty }
+        }
+        _ => unreachable!(),
+    };
+
+    quote! {
+        #(#attrs)*
+        impl lunatic::process::ProcessMessage<#message_type> for #ident {
+            fn handle(state: &mut Self::State, message: #message_type) {
+                state.#fn_ident(message)
+            }
+        }
+    }
+    .into()
+}
+
+fn render_process_request(item: &syn::ImplItemMethod, ident: &Box<syn::Type>) -> TokenStream {
+    let attrs = item
+        .attrs
+        .iter()
+        .filter(|attr| !attr.path.is_ident("process_request"));
+
+    let sig = &item.sig;
+    let fn_ident = &sig.ident;
+    let message_type = match sig.inputs.last().unwrap() {
+        syn::FnArg::Typed(arg) => {
+            let ty = &arg.ty;
+            quote! { #ty }
+        }
+        _ => unreachable!(),
+    };
+    let response_type = match &sig.output {
+        syn::ReturnType::Type(_, ty) => quote! { #ty },
+        syn::ReturnType::Default => {
+            quote! { () }
+        }
+    };
+
+    quote! {
+        #(#attrs)*
+        impl lunatic::process::ProcessRequest<#message_type> for #ident {
+            type Response = #response_type;
+            fn handle(state: &mut Self::State, request: #message_type) -> #response_type {
+                state.#fn_ident(request)
+            }
+        }
+    }
+    .into()
+}
+
+trait HasTag {
+    fn has_tag(&self, tag: &str) -> bool;
+}
+
+impl HasTag for syn::ImplItemMethod {
+    fn has_tag(&self, tag: &str) -> bool {
+        self.attrs.iter().any(|attr| attr.path.is_ident(tag))
+    }
+}

--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -270,10 +270,13 @@ impl AbstractProcessTransformer {
     }
 
     fn extract_process_message(&mut self, method: &syn::ImplItemMethod) {
-        let attrs = method
+        let mut method = method.clone();
+        method.attrs = method
             .attrs
-            .iter()
-            .filter(|attr| !attr.path.is_ident("process_message"));
+            .into_iter()
+            .filter(|attr| !attr.path.is_ident("process_message"))
+            .collect();
+        let attrs = &method.attrs;
 
         let HandlerComponents {
             fn_ident,
@@ -282,7 +285,7 @@ impl AbstractProcessTransformer {
             handler_arg_names,
             handler_arg_types,
             message_destructuring,
-        } = self.extract_handler_input(method);
+        } = self.extract_handler_input(&method);
 
         let ident = &self.impl_type.clone().unwrap();
 
@@ -312,10 +315,13 @@ impl AbstractProcessTransformer {
     }
 
     fn extract_process_request(&mut self, method: &syn::ImplItemMethod) {
-        let attrs = method
+        let mut method = method.clone();
+        method.attrs = method
             .attrs
-            .iter()
-            .filter(|attr| !attr.path.is_ident("process_request"));
+            .into_iter()
+            .filter(|attr| !attr.path.is_ident("process_request"))
+            .collect();
+        let attrs = &method.attrs;
 
         let HandlerComponents {
             fn_ident,
@@ -324,7 +330,7 @@ impl AbstractProcessTransformer {
             handler_arg_names,
             handler_arg_types,
             message_destructuring,
-        } = self.extract_handler_input(method);
+        } = self.extract_handler_input(&method);
 
         let ident = &self.impl_type.clone().unwrap();
 

--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -67,11 +67,11 @@ impl AbstractProcessTransformer {
                 Method(method) if method.has_tag("handle_link_trapped") => {
                     self.extract_handle_link_trapped(method)
                 }
-                Method(method) if method.has_tag("process_message") => {
-                    self.extract_process_message(method);
+                Method(method) if method.has_tag("handle_message") => {
+                    self.extract_handle_message(method);
                 }
-                Method(method) if method.has_tag("process_request") => {
-                    self.extract_process_request(method);
+                Method(method) if method.has_tag("handle_request") => {
+                    self.extract_handle_request(method);
                 }
                 _ => {
                     self.type_impls.skipped_items.push(quote! { #item });
@@ -269,12 +269,12 @@ impl AbstractProcessTransformer {
         });
     }
 
-    fn extract_process_message(&mut self, method: &syn::ImplItemMethod) {
+    fn extract_handle_message(&mut self, method: &syn::ImplItemMethod) {
         let mut method = method.clone();
         method.attrs = method
             .attrs
             .into_iter()
-            .filter(|attr| !attr.path.is_ident("process_message"))
+            .filter(|attr| !attr.path.is_ident("handle_message"))
             .collect();
         let attrs = &method.attrs;
 
@@ -316,12 +316,12 @@ impl AbstractProcessTransformer {
         self.type_impls.skipped_items.push(quote! { #method })
     }
 
-    fn extract_process_request(&mut self, method: &syn::ImplItemMethod) {
+    fn extract_handle_request(&mut self, method: &syn::ImplItemMethod) {
         let mut method = method.clone();
         method.attrs = method
             .attrs
             .into_iter()
-            .filter(|attr| !attr.path.is_ident("process_request"))
+            .filter(|attr| !attr.path.is_ident("handle_request"))
             .collect();
         let attrs = &method.attrs;
 

--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -133,7 +133,7 @@ impl AbstractProcessTransformer {
 
             #(#handler_impls)*
 
-            trait #handler_trait {
+            pub trait #handler_trait {
                 #(#handler_wrapper_defs)*
             }
 
@@ -308,6 +308,7 @@ impl AbstractProcessTransformer {
         });
         self.handler_wrappers.trait_impls.push(quote! {
             fn #fn_ident(&self, #(#handler_args),*) {
+                use lunatic::process::Message;
                 self.send(#message_type(#(#handler_arg_names),*));
             }
         });
@@ -361,6 +362,7 @@ impl AbstractProcessTransformer {
         });
         self.handler_wrappers.trait_impls.push(quote! {
             fn #fn_ident(&self, #(#handler_args),*) -> #response_type {
+                use lunatic::process::Request;
                 self.request(#message_type(#(#handler_arg_names),*))
             }
         });

--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -304,6 +304,7 @@ impl AbstractProcessTransformer {
             }
         });
         self.handler_wrappers.trait_defs.push(quote! {
+            #(#attrs)*
             fn #fn_ident(&self, #(#handler_args),*);
         });
         self.handler_wrappers.trait_impls.push(quote! {
@@ -358,6 +359,7 @@ impl AbstractProcessTransformer {
             }
         });
         self.handler_wrappers.trait_defs.push(quote! {
+            #(#attrs)*
             fn #fn_ident(&self, #(#handler_args),*) -> #response_type;
         });
         self.handler_wrappers.trait_impls.push(quote! {

--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -1,260 +1,347 @@
 use convert_case::{Case, Casing};
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, quote_spanned};
-use syn::ImplItem::Method;
+use quote::quote;
+use syn::{spanned::Spanned, ImplItem::Method};
 
-pub(crate) fn render_abstract_process(impl_block: syn::ItemImpl) -> TokenStream {
-    let impl_attrs = impl_block.attrs;
+/// Transform and expand the `abstract_process` macro
+#[derive(Default)]
+pub struct AbstractProcessTransformer {
+    /// impl type
+    impl_type: Option<syn::Type>,
+    /// impl type macros
+    impl_type_attrs: Vec<syn::Attribute>,
+    /// implmentation of trait `AbstractProcess`
+    ap_impls: AbstractProcessImpls,
+    /// Type impl block that is received by the macro
+    type_impls: TypeImpls,
+    /// Wrapper methods for send and request
+    handler_wrappers: HandlerWrappers,
+    /// message (message, request, and response) struct definitions
+    message_structs: Vec<TokenStream>,
+    /// impl blocks for ProcessMessage and ProcessRequest
+    handler_impls: Vec<TokenStream>,
+    /// compiler errors
+    errors: Vec<TokenStream>,
+}
 
-    // type that is being implemented
-    let impl_ty = *impl_block.self_ty;
-    let impl_ty_name = match &impl_ty {
-        syn::Type::Path(p) => p.path.get_ident().map(|i| i.to_string()),
-        _ => None,
-    };
+impl AbstractProcessTransformer {
+    pub fn new() -> Self {
+        Self::default()
+    }
 
-    // message (message, request, and response) struct definitions
-    let mut message_structs: Vec<TokenStream> = vec![];
-    // impl blocks for ProcessMessage and ProcessRequest
-    let mut process_impls: Vec<TokenStream> = vec![];
-    // AbstractProcess methods
-    let mut init_impl: Option<TokenStream> = None; // contains the State type
-    let mut terminate: Option<TokenStream> = None;
-    let mut handle_link_trapped: Option<TokenStream> = None;
-    // other items (e.g. helper methods) that will be left unchanged in the impl block
-    let mut skipped_items: Vec<TokenStream> = vec![];
-    // wrapper functions
-    let mut handler_func_defs: Vec<TokenStream> = vec![];
-    let mut handler_func_impls: Vec<TokenStream> = vec![];
+    pub fn transform(&mut self, impl_block: syn::ItemImpl) -> TokenStream {
+        self.extract(impl_block);
+        self.render()
+    }
 
-    for item in &impl_block.items {
-        match item {
-            Method(method) if method.has_tag("init") => init_impl = Some(render_init(method)),
-            Method(method) if method.has_tag("terminate") => {
-                terminate = Some(render_terminate(method));
+    fn extract(&mut self, impl_block: syn::ItemImpl) {
+        let impl_block_span = impl_block.span();
+
+        self.impl_type_attrs = impl_block.attrs;
+        self.impl_type = Some(*impl_block.self_ty);
+        self.handler_wrappers.trait_name = {
+            match &self.impl_type {
+                Some(syn::Type::Path(p)) => p
+                    .path
+                    .get_ident()
+                    .map(|i| i.to_string())
+                    .map(|s| syn::Ident::new(&format!("{}Handler", s), Span::call_site())),
+                _ => None,
             }
-            Method(method) if method.has_tag("handle_link_trapped") => {
-                handle_link_trapped = Some(render_handle_link_trapped(method));
+            .or_else(|| {
+                let err = syn::Error::new(
+                    impl_block_span,
+                    "Only path (type) impl is supported by `#[abstract_process]`",
+                )
+                .to_compile_error();
+                self.errors.push(err);
+                // create temporary to silence error from invalid syntax
+                Some(syn::Ident::new("__Placeholder", Span::call_site()))
+            })
+        };
+
+        for item in &impl_block.items {
+            match item {
+                Method(method) if method.has_tag("init") => self.extract_init(method),
+                Method(method) if method.has_tag("terminate") => self.extract_terminate(method),
+                Method(method) if method.has_tag("handle_link_trapped") => {
+                    self.extract_handle_link_trapped(method)
+                }
+                Method(method) if method.has_tag("process_message") => {
+                    self.extract_process_message(method);
+                }
+                Method(method) if method.has_tag("process_request") => {
+                    self.extract_process_request(method);
+                }
+                _ => {
+                    self.type_impls.skipped_items.push(quote! { #item });
+                }
             }
-            Method(method) if method.has_tag("process_message") => {
-                let (msg_struct, process_imp, handle_func_def, handle_func_impl) =
-                    render_process_message(method, &impl_ty);
-                message_structs.push(msg_struct);
-                process_impls.push(process_imp);
-                handler_func_defs.push(handle_func_def);
-                handler_func_impls.push(handle_func_impl);
-                skipped_items.push(quote! { #method });
+        }
+
+        // ensure init exists
+        if self.ap_impls.init.is_none() {
+            let err = syn::Error::new(
+                impl_block_span,
+                "Must implement the `init` method marked with `#[init]`",
+            )
+            .to_compile_error();
+            self.errors.push(err);
+        }
+    }
+
+    fn render(&self) -> TokenStream {
+        let errors = &self.errors;
+        let impl_type = &self.impl_type;
+        let AbstractProcessImpls {
+            init: init_impl,
+            terminate: terminate_impl,
+            handle_link_trapped: handle_link_trapped_impl,
+        } = &self.ap_impls;
+        let TypeImpls {
+            terminate,
+            handle_link_trapped,
+            skipped_items,
+        } = &self.type_impls;
+        let message_structs = &self.message_structs;
+        let impl_attrs = &self.impl_type_attrs;
+        let handler_impls = &self.handler_impls;
+        let HandlerWrappers {
+            trait_name: handler_trait,
+            trait_defs: handler_wrapper_defs,
+            trait_impls: handler_wrapper_impls,
+        } = &self.handler_wrappers;
+
+        quote! {
+            #(#errors)*
+
+            #(#message_structs)*
+
+            #(#impl_attrs)*
+            impl #impl_type {
+                #terminate
+                #handle_link_trapped
+                #(#skipped_items)*
             }
-            Method(method) if method.has_tag("process_request") => {
-                let (msg_structs, process_imp, handle_func_def, handle_func_impl) =
-                    render_process_request(method, &impl_ty);
-                message_structs.push(msg_structs);
-                process_impls.push(process_imp);
-                handler_func_defs.push(handle_func_def);
-                handler_func_impls.push(handle_func_impl);
-                skipped_items.push(quote! { #method });
+
+            impl lunatic::process::AbstractProcess for #impl_type {
+                type State = #impl_type;
+                #init_impl
+                #terminate_impl
+                #handle_link_trapped_impl
             }
-            _ => {
-                skipped_items.push(quote! { #item });
+
+            #(#handler_impls)*
+
+            trait #handler_trait {
+                #(#handler_wrapper_defs)*
+            }
+
+            impl #handler_trait for lunatic::process::ProcessRef<#impl_type> {
+                #(#handler_wrapper_impls)*
             }
         }
     }
 
-    // The extra clone will be optimized away by the compiler so we can write more concise code
-    let terminate_impl = terminate.clone().map(|_| {
-        quote! {
+    fn extract_init(&mut self, method: &syn::ImplItemMethod) {
+        if let Some(_) = self.ap_impls.init {
+            let err = syn::Error::new(
+                method.sig.ident.span(),
+                "Only one method can be marked with `#[init]` macro",
+            )
+            .into_compile_error();
+            self.errors.push(err);
+            return;
+        }
+        let attrs = method
+            .attrs
+            .iter()
+            .filter(|attr| !attr.path.is_ident("init"));
+
+        let sig = &method.sig;
+        // ensure function name is init
+        let ident = &sig.ident;
+        let error = if sig.ident != "init" {
+            Some(
+                syn::Error::new(
+                    sig.ident.span(),
+                    "Invalid method signature. Method name must be `init`.",
+                )
+                .into_compile_error(),
+            )
+        } else {
+            None
+        };
+
+        let arg_type = if let Some(syn::FnArg::Typed(arg)) = sig.inputs.last() {
+            &arg.ty
+        } else {
+            unreachable!("Other cases will be caught prior to this at syn::parse")
+        };
+        let func_args = &sig.inputs;
+        let block = &method.block;
+
+        self.ap_impls.init = Some(quote! {
+            #error
+
+            type Arg = #arg_type;
+
+            #(#attrs)*
+            fn #ident(#func_args) -> Self::State #block
+        });
+    }
+
+    fn extract_terminate(&mut self, method: &syn::ImplItemMethod) {
+        if let Some(_) = self.type_impls.terminate {
+            let err = syn::Error::new(
+                method.sig.ident.span(),
+                "Only one method can be marked with `#[terminate]` macro",
+            )
+            .into_compile_error();
+            self.errors.push(err);
+        }
+        let sig = &method.sig;
+        // ensure function name is terminate
+        let ident = &sig.ident;
+        let error = if sig.ident != "terminate" {
+            Some(
+                syn::Error::new(
+                    sig.ident.span(),
+                    "Invalid method signature. Method name must be `terminate`.",
+                )
+                .into_compile_error(),
+            )
+        } else {
+            None
+        };
+
+        let self_arg = &sig.inputs;
+        let block = &method.block;
+
+        self.type_impls.terminate = Some(quote! {
+            #error
+
+            fn #ident(#self_arg) #block
+        });
+        self.ap_impls.terminate = Some(quote! {
             fn terminate(state: Self::State) {
                 state.terminate()
             }
+        });
+    }
+
+    fn extract_handle_link_trapped(&mut self, method: &syn::ImplItemMethod) {
+        if let Some(_) = self.type_impls.handle_link_trapped {
+            let err = syn::Error::new(
+                method.sig.ident.span(),
+                "Only one method can be marked with `#[handle_link_trapped]` macro",
+            )
+            .into_compile_error();
+            self.errors.push(err);
         }
-    });
-    let handle_link_trapped_impl = handle_link_trapped.clone().map(|_| {
-        quote! {
+        let sig = &method.sig;
+        // ensure function name is handle_link_trapped
+        let ident = &sig.ident;
+        let error = if sig.ident != "handle_link_trapped" {
+            Some(
+                syn::Error::new(
+                    sig.ident.span(),
+                    "Invalid method signature. Method name must be `handle_link_trapped`.",
+                )
+                .into_compile_error(),
+            )
+        } else {
+            None
+        };
+
+        let self_arg = &sig.inputs;
+        let block = &method.block;
+
+        self.type_impls.handle_link_trapped = Some(quote! {
+            #error
+
+            fn #ident(#self_arg) #block
+        });
+        self.ap_impls.handle_link_trapped = Some(quote! {
             fn handle_link_trapped(state: &mut Self::State, tag: Tag) {
                 state.handle_link_trapped(tag);
             }
-        }
-    });
-
-    let handler_trait = format!("{}Handler", impl_ty_name.unwrap());
-    let handler_trait = proc_macro2::Ident::new(&handler_trait, Span::call_site());
-
-    quote! {
-        #(#message_structs)*
-
-        #(#impl_attrs)*
-        impl #impl_ty {
-            #terminate
-            #handle_link_trapped
-            #(#skipped_items)*
-        }
-
-        impl lunatic::process::AbstractProcess for #impl_ty {
-            type State = #impl_ty;
-            #init_impl
-            #terminate_impl
-            #handle_link_trapped_impl
-        }
-
-        #(#process_impls)*
-
-        trait #handler_trait {
-            #(#handler_func_defs)*
-        }
-
-        impl #handler_trait for lunatic::process::ProcessRef<#impl_ty> {
-            #(#handler_func_impls)*
-        }
+        });
     }
-}
 
-fn render_init(item: &syn::ImplItemMethod) -> TokenStream {
-    let attrs = item.attrs.iter().filter(|attr| !attr.path.is_ident("init"));
+    fn extract_process_message(&mut self, method: &syn::ImplItemMethod) {
+        let attrs = method
+            .attrs
+            .iter()
+            .filter(|attr| !attr.path.is_ident("process_message"));
 
-    let sig = &item.sig;
-    // ensure function name is init
-    let ident = if sig.ident != "init" {
-        quote_spanned! {
-            sig.ident.span() => compile_error!("Invalid function signature. Function name must be `init`.");
-        }
-    } else {
-        let ident = &sig.ident;
-        quote! { #ident }
-    };
+        let HandlerComponents {
+            fn_ident,
+            message_type,
+            handler_args,
+            handler_arg_names,
+            handler_arg_types,
+            message_destructuring,
+        } = self.extract_handler_input(method);
 
-    let arg_type = if let syn::FnArg::Typed(arg) = sig.inputs.last().unwrap() {
-        &arg.ty
-    } else {
-        unreachable!()
-    };
-    let func_args = &sig.inputs;
-    let block = &item.block;
+        let ident = &self.impl_type.clone().unwrap();
 
-    quote! {
-        type Arg = #arg_type;
-
-        #(#attrs)*
-        fn #ident(#func_args) -> Self::State #block
-    }
-}
-
-fn render_terminate(item: &syn::ImplItemMethod) -> TokenStream {
-    let sig = &item.sig;
-    // ensure function name is init
-    let ident = if sig.ident != "terminate" {
-        quote_spanned! {
-            sig.ident.span() => compile_error!("Invalid function signature. Function name must be `terminate`.");
-        }
-    } else {
-        let ident = &sig.ident;
-        quote! { #ident }
-    };
-
-    let self_arg = &sig.inputs;
-    let block = &item.block;
-
-    quote! {
-        fn #ident(#self_arg) #block
-    }
-}
-
-fn render_handle_link_trapped(item: &syn::ImplItemMethod) -> TokenStream {
-    let sig = &item.sig;
-    // ensure function name is init
-    let ident = if sig.ident != "handle_link_trapped" {
-        quote_spanned! {
-            sig.ident.span() => compile_error!("Invalid function signature. Function name must be `handle_link_trapped`.");
-        }
-    } else {
-        let ident = &sig.ident;
-        quote! { #ident }
-    };
-
-    let self_arg = &sig.inputs;
-    let block = &item.block;
-
-    quote! {
-        fn #ident(#self_arg) #block
-    }
-}
-
-fn render_process_message(
-    item: &syn::ImplItemMethod,
-    ident: &syn::Type,
-) -> (TokenStream, TokenStream, TokenStream, TokenStream) {
-    let attrs = item
-        .attrs
-        .iter()
-        .filter(|attr| !attr.path.is_ident("process_message"));
-
-    let HandlerComponents {
-        fn_ident,
-        message_type,
-        handler_args,
-        handler_arg_names,
-        handler_arg_types,
-        message_destructuring,
-    } = extract_handler_input(item);
-
-    (
-        quote! {
+        self.message_structs.push(quote! {
             #[derive(serde::Serialize, serde::Deserialize)]
             struct #message_type (
                 #(#handler_arg_types),*
             );
-        },
-        quote! {
+        });
+        self.handler_impls.push(quote! {
             #(#attrs)*
             impl lunatic::process::ProcessMessage<#message_type> for #ident {
                 fn handle(state: &mut Self::State, message: #message_type) {
                     state.#fn_ident(#(#message_destructuring),*)
                 }
             }
-        },
-        quote! {
+        });
+        self.handler_wrappers.trait_defs.push(quote! {
             fn #fn_ident(&self, #(#handler_args),*);
-        },
-        quote! {
+        });
+        self.handler_wrappers.trait_impls.push(quote! {
             fn #fn_ident(&self, #(#handler_args),*) {
                 self.send(#message_type(#(#handler_arg_names),*));
             }
-        },
-    )
-}
+        });
+        self.type_impls.skipped_items.push(quote! { #method })
+    }
 
-fn render_process_request(
-    item: &syn::ImplItemMethod,
-    ident: &syn::Type,
-) -> (TokenStream, TokenStream, TokenStream, TokenStream) {
-    let attrs = item
-        .attrs
-        .iter()
-        .filter(|attr| !attr.path.is_ident("process_request"));
+    fn extract_process_request(&mut self, method: &syn::ImplItemMethod) {
+        let attrs = method
+            .attrs
+            .iter()
+            .filter(|attr| !attr.path.is_ident("process_request"));
 
-    let HandlerComponents {
-        fn_ident,
-        message_type,
-        handler_args,
-        handler_arg_names,
-        handler_arg_types,
-        message_destructuring,
-    } = extract_handler_input(item);
+        let HandlerComponents {
+            fn_ident,
+            message_type,
+            handler_args,
+            handler_arg_names,
+            handler_arg_types,
+            message_destructuring,
+        } = self.extract_handler_input(method);
 
-    let response_type = match &item.sig.output {
-        syn::ReturnType::Type(_, ty) => quote! { #ty },
-        syn::ReturnType::Default => {
-            quote! { () }
-        }
-    };
+        let ident = &self.impl_type.clone().unwrap();
 
-    (
-        quote! {
+        let response_type = match &method.sig.output {
+            syn::ReturnType::Type(_, ty) => quote! { #ty },
+            syn::ReturnType::Default => {
+                quote! { () }
+            }
+        };
+
+        self.message_structs.push(quote! {
             #[derive(serde::Serialize, serde::Deserialize)]
             struct #message_type (
                 #(#handler_arg_types),*
             );
-        },
-        quote! {
+        });
+        self.handler_impls.push(quote! {
             #(#attrs)*
             impl lunatic::process::ProcessRequest<#message_type> for #ident {
                 type Response = #response_type;
@@ -262,62 +349,64 @@ fn render_process_request(
                     state.#fn_ident(#(#message_destructuring),*)
                 }
             }
-        },
-        quote! {
+        });
+        self.handler_wrappers.trait_defs.push(quote! {
             fn #fn_ident(&self, #(#handler_args),*) -> #response_type;
-        },
-        quote! {
+        });
+        self.handler_wrappers.trait_impls.push(quote! {
             fn #fn_ident(&self, #(#handler_args),*) -> #response_type {
                 self.request(#message_type(#(#handler_arg_names),*))
             }
-        },
-    )
-}
-
-fn extract_handler_input(item: &syn::ImplItemMethod) -> HandlerComponents {
-    let sig = &item.sig;
-    let fn_ident = &sig.ident;
-    let message_type = proc_macro2::Ident::new(
-        &format!("__MsgWrap{}", fn_ident.to_string().to_case(Case::Pascal)),
-        Span::call_site(),
-    );
-
-    // wrap message types
-    let mut handler_args: Vec<TokenStream> = vec![];
-    let mut handler_arg_names: Vec<syn::Ident> = vec![];
-    let mut handler_arg_types: Vec<syn::Type> = vec![];
-
-    for (i, arg) in sig.inputs.iter().skip(1).enumerate() {
-        let ident = match arg {
-            syn::FnArg::Typed(arg) => match *arg.pat.clone() {
-                // replace pattern matching arguments
-                syn::Pat::Ident(pat_ident) => pat_ident.ident,
-                _ => proc_macro2::Ident::new(&format!("__arg_{}", i), Span::call_site()),
-            },
-            _ => unreachable!(),
-        };
-        let ty = match arg {
-            syn::FnArg::Typed(arg) => *arg.ty.clone(),
-            _ => unreachable!(),
-        };
-        handler_args.push(quote! { #ident: #ty });
-        handler_arg_names.push(ident);
-        handler_arg_types.push(ty);
+        });
+        self.type_impls.skipped_items.push(quote! { #method })
     }
-    let message_destructuring = (0..handler_arg_types.len())
-        .map(|i| {
-            let i = proc_macro2::Literal::usize_unsuffixed(i);
-            quote! { message.#i }
-        })
-        .collect();
 
-    HandlerComponents {
-        fn_ident: fn_ident.clone(),
-        message_type,
-        handler_args,
-        handler_arg_names,
-        handler_arg_types,
-        message_destructuring,
+    fn extract_handler_input(&self, item: &syn::ImplItemMethod) -> HandlerComponents {
+        let sig = &item.sig;
+        let fn_ident = &sig.ident;
+        let message_type = proc_macro2::Ident::new(
+            &format!("__MsgWrap{}", fn_ident.to_string().to_case(Case::Pascal)),
+            Span::call_site(),
+        );
+
+        // wrap message types
+        let mut handler_args: Vec<TokenStream> = vec![];
+        let mut handler_arg_names: Vec<syn::Ident> = vec![];
+        let mut handler_arg_types: Vec<syn::Type> = vec![];
+
+        for (i, arg) in sig.inputs.iter().skip(1).enumerate() {
+            // take apart the argument identifiers and their types
+            let (ident, ty) = match arg {
+                syn::FnArg::Typed(arg) => {
+                    let ident = match *arg.pat.clone() {
+                        // replace patterns with generated identifiers to prevent syntax error
+                        syn::Pat::Ident(pat_ident) => pat_ident.ident,
+                        _ => proc_macro2::Ident::new(&format!("__arg_{}", i), Span::call_site()),
+                    };
+                    (ident, *arg.ty.clone())
+                }
+                _ => unreachable!("Second arguement, if exist, will always be typed"),
+            };
+            // rebuild args list
+            handler_args.push(quote! { #ident: #ty });
+            handler_arg_names.push(ident);
+            handler_arg_types.push(ty);
+        }
+        let message_destructuring = (0..handler_arg_types.len())
+            .map(|i| {
+                let i = proc_macro2::Literal::usize_unsuffixed(i);
+                quote! { message.#i }
+            })
+            .collect();
+
+        HandlerComponents {
+            fn_ident: fn_ident.clone(),
+            message_type,
+            handler_args,
+            handler_arg_names,
+            handler_arg_types,
+            message_destructuring,
+        }
     }
 }
 
@@ -328,6 +417,27 @@ struct HandlerComponents {
     handler_arg_names: Vec<syn::Ident>,
     handler_arg_types: Vec<syn::Type>,
     message_destructuring: Vec<TokenStream>,
+}
+
+#[derive(Default)]
+struct TypeImpls {
+    terminate: Option<TokenStream>,
+    handle_link_trapped: Option<TokenStream>,
+    skipped_items: Vec<TokenStream>,
+}
+
+#[derive(Default)]
+struct AbstractProcessImpls {
+    init: Option<TokenStream>,
+    terminate: Option<TokenStream>,
+    handle_link_trapped: Option<TokenStream>,
+}
+
+#[derive(Default)]
+struct HandlerWrappers {
+    trait_name: Option<syn::Ident>,
+    trait_defs: Vec<TokenStream>,
+    trait_impls: Vec<TokenStream>,
 }
 
 trait HasTag {

--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -278,7 +278,7 @@ fn extract_handler_input(item: &syn::ImplItemMethod) -> HandlerComponents {
     let sig = &item.sig;
     let fn_ident = &sig.ident;
     let message_type = proc_macro2::Ident::new(
-        &format!("__lunatic_{}", fn_ident.to_string().to_case(Case::Pascal)),
+        &format!("__MsgWrap{}", fn_ident.to_string().to_case(Case::Pascal)),
         Span::call_site(),
     );
 

--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -187,14 +187,14 @@ fn render_process_message(
         .iter()
         .filter(|attr| !attr.path.is_ident("process_message"));
 
-    let (
+    let HandlerComponents {
         fn_ident,
         message_type,
         handler_args,
         handler_arg_names,
         handler_arg_types,
         message_destructuring,
-    ) = extract_handler_input(item);
+    } = extract_handler_input(item);
 
     (
         quote! {
@@ -231,14 +231,14 @@ fn render_process_request(
         .iter()
         .filter(|attr| !attr.path.is_ident("process_request"));
 
-    let (
+    let HandlerComponents {
         fn_ident,
         message_type,
         handler_args,
         handler_arg_names,
         handler_arg_types,
         message_destructuring,
-    ) = extract_handler_input(item);
+    } = extract_handler_input(item);
 
     let response_type = match &item.sig.output {
         syn::ReturnType::Type(_, ty) => quote! { #ty },
@@ -274,16 +274,7 @@ fn render_process_request(
     )
 }
 
-fn extract_handler_input(
-    item: &syn::ImplItemMethod,
-) -> (
-    &syn::Ident,
-    syn::Ident,
-    Vec<TokenStream>,
-    Vec<syn::Ident>,
-    Vec<syn::Type>,
-    Vec<TokenStream>,
-) {
+fn extract_handler_input(item: &syn::ImplItemMethod) -> HandlerComponents {
     let sig = &item.sig;
     let fn_ident = &sig.ident;
     let message_type = proc_macro2::Ident::new(
@@ -320,14 +311,23 @@ fn extract_handler_input(
         })
         .collect();
 
-    (
-        fn_ident,
+    HandlerComponents {
+        fn_ident: fn_ident.clone(),
         message_type,
         handler_args,
         handler_arg_names,
         handler_arg_types,
         message_destructuring,
-    )
+    }
+}
+
+struct HandlerComponents {
+    fn_ident: syn::Ident,
+    message_type: syn::Ident,
+    handler_args: Vec<TokenStream>,
+    handler_arg_names: Vec<syn::Ident>,
+    handler_arg_types: Vec<syn::Type>,
+    message_destructuring: Vec<TokenStream>,
 }
 
 trait HasTag {

--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -144,7 +144,7 @@ impl AbstractProcessTransformer {
     }
 
     fn extract_init(&mut self, method: &syn::ImplItemMethod) {
-        if let Some(_) = self.ap_impls.init {
+        if self.ap_impls.init.is_some() {
             let err = syn::Error::new(
                 method.sig.ident.span(),
                 "Only one method can be marked with `#[init]` macro",
@@ -192,7 +192,7 @@ impl AbstractProcessTransformer {
     }
 
     fn extract_terminate(&mut self, method: &syn::ImplItemMethod) {
-        if let Some(_) = self.type_impls.terminate {
+        if self.type_impls.terminate.is_some() {
             let err = syn::Error::new(
                 method.sig.ident.span(),
                 "Only one method can be marked with `#[terminate]` macro",
@@ -231,7 +231,7 @@ impl AbstractProcessTransformer {
     }
 
     fn extract_handle_link_trapped(&mut self, method: &syn::ImplItemMethod) {
-        if let Some(_) = self.type_impls.handle_link_trapped {
+        if self.type_impls.handle_link_trapped.is_some() {
             let err = syn::Error::new(
                 method.sig.ident.span(),
                 "Only one method can be marked with `#[handle_link_trapped]` macro",

--- a/lunatic-macros/src/lib.rs
+++ b/lunatic-macros/src/lib.rs
@@ -40,7 +40,7 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// - Use **#\[init\]**, **#\[terminate\]**, and **#\[handle_link_trapped\]** attributes to
 /// specify methods for implementing lunatic::process::AbstractProcess.
-/// - Use **#\[process_message\]** and **#\[process_request\]** attributes to specify
+/// - Use **#\[handle_message\]** and **#\[handle_request\]** attributes to specify
 /// message and request handlers.
 ///
 /// Specifying message types is unnecessary because the macro will create wrapper
@@ -76,12 +76,12 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
 ///         println!("Link trapped");
 ///     }
 ///
-///     #[process_message]
+///     #[handle_message]
 ///     fn increment(&mut self) {
 ///         self.0 += 1;
 ///     }
 ///
-///     #[process_request]
+///     #[handle_request]
 ///     fn count(&self) -> u32 {
 ///         self.0
 ///     }

--- a/lunatic-macros/src/lib.rs
+++ b/lunatic-macros/src/lib.rs
@@ -35,12 +35,12 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Add AbstractProcess behaviour to the given struct implementation with minimum
-/// boilerplate code.
+/// Add [`AbstractProcess`][lunatic::process:AbstractProcess] behavior to the given struct
+/// implementation with minimum boilerplate code.
 ///
-/// - Use **#\[init\]**, **#\[terminate\]**, and **#\[handle_link_trapped\]** marker macros to
+/// - Use **#\[init\]**, **#\[terminate\]**, and **#\[handle_link_trapped\]** attributes to
 /// specify methods for implementing lunatic::process::AbstractProcess.
-/// - Use **#\[process_message\]** and **#\[process_request\]** marker macros to specify
+/// - Use **#\[process_message\]** and **#\[process_request\]** attributes to specify
 /// message and request handlers.
 ///
 /// Specifying message types is unnecessary because the macro will create wrapper
@@ -51,25 +51,39 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// use lunatic::process::{Message, ProcessRef, Request, StartProcess};
+/// use lunatic::{
+///     process::{Message, ProcessRef, Request, StartProcess},
+///     Tag,
+/// };
 /// use lunatic_macros::{abstract_process, process_message, process_request};
 ///
 /// struct Counter(u32);
 ///
 /// #[abstract_process]
 /// impl Counter {
+///     #[init]
 ///     fn init(_: ProcessRef<Self>, start: u32) -> Self {
 ///         Self(start)
 ///     }
 ///
+///     #[terminate]
+///     fn terminate(self) {
+///         println!("Shutdown process");
+///     }
+///
+///     #[handle_link_trapped]
+///     fn handle_link_trapped(&self, tag: Tag) {
+///         println!("Link trapped");
+///     }
+///
 ///     #[process_message]
 ///     fn increment(&mut self) {
-///         state.0 += 1;
+///         self.0 += 1;
 ///     }
 ///
 ///     #[process_request]
 ///     fn count(&self) -> u32 {
-///         state.0
+///         self.0
 ///     }
 /// }
 ///
@@ -77,6 +91,61 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
 /// let counter = Counter::start(5, None);
 /// counter.increment();
 /// assert_eq!(counter.count(), 6);
+/// ```
+///
+/// A more complicated example
+///
+/// ```
+/// use lunatic::process::{Message, ProcessRef, Request, StartProcess};
+/// use lunatic_macros::{abstract_process, process_message, process_request};
+///
+///
+/// struct A;
+///
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct Person {
+///     name: String,
+///     age: u16,
+/// }
+///
+/// #[abstract_process]
+/// impl A {
+///     #[init]
+///     fn init(_: ProcessRef<Self>, _: ()) -> A {
+///         A
+///     }
+///
+///     #[process_message]
+///     fn multiple_arguments(&self, a: u8, (b, c): (bool, char)) {
+///         assert_eq!(a, 5);
+///         assert_eq!(b, false);
+///         assert_eq!(c, 'a');
+///     }
+///
+///     #[process_request]
+///     fn unpack_struct(&self, Person { name, age }: Person) -> String {
+///         assert_eq!(name, "Mark");
+///         assert_eq!(age, 5);
+///         self.create_greeting(name)
+///     }
+///
+///     fn create_greeting(&self, name: String) {
+///         format!("Hi {}!", name)
+///     }
+/// }
+///
+/// let a = A::start_link((), None);
+///
+/// a.multiple_arguments(5, (false, 'a'));
+///
+/// let person = Person {
+///     name: "Mark".to_owned(),
+///     age: 4,
+/// };
+///
+/// let greeting = a.unpack_struct(person);
+/// assert_eq!(greeting, "Hi Mark!");
+///
 /// ```
 #[proc_macro_attribute]
 pub fn abstract_process(_args: TokenStream, item: TokenStream) -> TokenStream {

--- a/lunatic-macros/src/lib.rs
+++ b/lunatic-macros/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(box_patterns)]
 #[allow(unused_extern_crates)]
 extern crate proc_macro;
 use proc_macro::TokenStream;

--- a/lunatic-macros/src/lib.rs
+++ b/lunatic-macros/src/lib.rs
@@ -38,7 +38,7 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn abstract_process(_args: TokenStream, item: TokenStream) -> TokenStream {
     match syn::parse(item.clone()) {
-        Ok(it) => render_abstract_process(it),
+        Ok(it) => render_abstract_process(it).into(),
         Err(e) => token_stream_with_error(item, e),
     }
 }

--- a/lunatic-macros/src/lib.rs
+++ b/lunatic-macros/src/lib.rs
@@ -52,10 +52,10 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```
 /// use lunatic::{
+///     abstract_process,
 ///     process::{Message, ProcessRef, Request, StartProcess},
 ///     Tag,
 /// };
-/// use lunatic_macros::{abstract_process, process_message, process_request};
 ///
 /// struct Counter(u32);
 ///
@@ -96,8 +96,10 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
 /// A more complicated example
 ///
 /// ```
-/// use lunatic::process::{Message, ProcessRef, Request, StartProcess};
-/// use lunatic_macros::{abstract_process, process_message, process_request};
+/// use lunatic::{
+///     abstract_process,
+///     process::{Message, ProcessRef, Request, StartProcess},
+/// }
 ///
 ///
 /// struct A;
@@ -153,31 +155,6 @@ pub fn abstract_process(_args: TokenStream, item: TokenStream) -> TokenStream {
         Ok(it) => AbstractProcessTransformer::new().transform(it).into(),
         Err(e) => token_stream_with_error(item, e),
     }
-}
-
-#[proc_macro_attribute]
-pub fn init(_args: TokenStream, item: TokenStream) -> TokenStream {
-    item
-}
-
-#[proc_macro_attribute]
-pub fn terminate(_args: TokenStream, item: TokenStream) -> TokenStream {
-    item
-}
-
-#[proc_macro_attribute]
-pub fn handle_link_trapped(_args: TokenStream, item: TokenStream) -> TokenStream {
-    item
-}
-
-#[proc_macro_attribute]
-pub fn process_message(_args: TokenStream, item: TokenStream) -> TokenStream {
-    item
-}
-
-#[proc_macro_attribute]
-pub fn process_request(_args: TokenStream, item: TokenStream) -> TokenStream {
-    item
 }
 
 fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenStream {

--- a/lunatic-macros/src/lib.rs
+++ b/lunatic-macros/src/lib.rs
@@ -117,14 +117,14 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
 ///         A
 ///     }
 ///
-///     #[process_message]
+///     #[hanlde_message]
 ///     fn multiple_arguments(&self, a: u8, (b, c): (bool, char)) {
 ///         assert_eq!(a, 5);
 ///         assert_eq!(b, false);
 ///         assert_eq!(c, 'a');
 ///     }
 ///
-///     #[process_request]
+///     #[handle_request]
 ///     fn unpack_struct(&self, Person { name, age }: Person) -> String {
 ///         assert_eq!(name, "Mark");
 ///         assert_eq!(age, 5);

--- a/lunatic-macros/src/lib.rs
+++ b/lunatic-macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(box_patterns)]
 #[allow(unused_extern_crates)]
 extern crate proc_macro;
 use proc_macro::TokenStream;

--- a/lunatic-macros/src/lib.rs
+++ b/lunatic-macros/src/lib.rs
@@ -1,8 +1,10 @@
 #[allow(unused_extern_crates)]
 extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use quote::quote;
+
+mod abstract_process;
+use abstract_process::render_abstract_process;
 
 #[proc_macro_attribute]
 pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
@@ -31,6 +33,39 @@ pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
     .into()
+}
+
+#[proc_macro_attribute]
+pub fn abstract_process(_args: TokenStream, item: TokenStream) -> TokenStream {
+    match syn::parse(item.clone()) {
+        Ok(it) => render_abstract_process(it),
+        Err(e) => token_stream_with_error(item, e),
+    }
+}
+
+#[proc_macro_attribute]
+pub fn init(_args: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+#[proc_macro_attribute]
+pub fn terminate(_args: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+#[proc_macro_attribute]
+pub fn handle_link_trapped(_args: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+#[proc_macro_attribute]
+pub fn process_message(_args: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+#[proc_macro_attribute]
+pub fn process_request(_args: TokenStream, item: TokenStream) -> TokenStream {
+    item
 }
 
 fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub use mailbox::{Mailbox, ReceiveError};
 pub use module::WasmModule;
 pub use tag::Tag;
 
-pub use lunatic_macros::main;
+pub use lunatic_macros::{abstract_process, main};
 pub use lunatic_test::test;
 
 /// Implemented for all resources held by the VM.

--- a/tests/abstract_process_macro.rs
+++ b/tests/abstract_process_macro.rs
@@ -1,75 +1,30 @@
-use lunatic::process::SelfReference;
 use lunatic::{
+    host,
     process::{Message, ProcessRef, Request, StartProcess},
-    sleep, test, Tag,
+    sleep, spawn_link, test, Tag,
 };
 use lunatic_macros::{abstract_process, process_message, process_request};
 use std::time::Duration;
 
-#[derive(Debug)]
-struct Counter {
-    count: u32,
-}
+#[test]
+fn init() {
+    struct A;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-struct Panic;
-#[derive(serde::Serialize, serde::Deserialize)]
-struct Inc;
-#[derive(serde::Serialize, serde::Deserialize)]
-struct Count;
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
-struct CountReply(u32);
-
-#[abstract_process]
-impl Counter {
-    #[init]
-    fn init(_process: ProcessRef<Self>, count: u32) -> Self {
-        Self { count }
-    }
-
-    #[terminate]
-    fn terminate(self) {
-        println!("Shutting down with state {}", self.count);
-    }
-
-    #[handle_link_trapped]
-    fn handle_link_trapped(&mut self, tag: Tag) {
-        println!("{:?}", tag);
-    }
-
-    #[process_message]
-    fn increment(&mut self, _: Inc) {
-        self.count += 1;
-        self.check_count();
-    }
-
-    #[process_message]
-    fn panic(&mut self, _: Panic) {
-        panic!();
-    }
-
-    #[process_request]
-    fn count(&self, _: Count) -> CountReply {
-        CountReply(self.count)
-    }
-
-    fn check_count(&self) {
-        if self.count > 5 {
-            println!("count exceeded 5!");
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_process: ProcessRef<Self>, _count: (u32, String)) -> Self {
+            Self {}
         }
     }
-}
 
-#[test]
-fn init_and_terminate() {
-    let counter = Counter::start_link(2, None);
-    counter.increment(Inc);
-    counter.increment(Inc);
-    counter.increment(Inc);
-    counter.increment(Inc);
-    counter.increment(Inc);
-    dbg!(counter.count(Count));
-    counter.panic(Panic);
+    A::start_link(
+        (
+            42,
+            "the meaning of life, the universe, and everything".to_owned(),
+        ),
+        None,
+    );
 }
 
 #[test]
@@ -94,170 +49,89 @@ fn shutdown() {
 }
 
 #[test]
-fn handle_message() {
-    struct A;
-
-    #[abstract_process]
-    impl A {
-        #[init]
-        fn init(_: ProcessRef<Self>, _: ()) -> A {
-            A
-        }
-
-        #[process_message]
-        fn handle(&self, message: String) {
-            assert_eq!(message, "Hello world");
-        }
+fn handle_link_trapped() {
+    struct A {
+        link_trapped: bool,
     }
 
-    let a = A::start_link((), None);
-    a.handle("Hello world".to_owned());
-
-    sleep(Duration::from_millis(100));
-}
-
-#[test]
-fn handle_request() {
-    struct A;
-
     #[abstract_process]
     impl A {
         #[init]
-        fn init(_: ProcessRef<Self>, _: ()) -> A {
-            A
-        }
-
-        #[process_request]
-        fn handle(&mut self, mut request: String) -> String {
-            request.push_str(" world");
-            request
-        }
-    }
-
-    let a = A::start_link((), None);
-    let response = a.handle("Hello".to_owned());
-
-    assert_eq!(response, "Hello world");
-}
-
-#[test]
-fn init_args() {
-    struct A(Vec<f64>);
-
-    #[derive(serde::Serialize, serde::Deserialize)]
-    struct Sum;
-
-    #[abstract_process]
-    impl A {
-        #[init]
-        fn init(_: ProcessRef<Self>, arg: Vec<f64>) -> A {
-            A(arg)
-        }
-
-        #[process_message]
-        fn add(&mut self, message: f64) {
-            self.0.push(message);
-        }
-
-        #[process_request]
-        fn sum(&mut self, _: Sum) -> f64 {
-            self.0.iter().sum()
-        }
-    }
-
-    let init = vec![0.1, 0.1, 0.1, 0.2];
-    let a = A::start_link(init, None);
-
-    a.add(0.2);
-    a.add(0.2);
-    a.add(0.1);
-    a.add(1.0);
-    assert_eq!(a.sum(Sum), 2.0);
-    a.add(0.1);
-    assert_eq!(a.sum(Sum), 2.1);
-    a.add(0.1);
-    assert_eq!(a.sum(Sum), 2.2);
-    a.add(0.3);
-    assert_eq!(a.sum(Sum), 2.5);
-    a.add(0.1);
-    assert_eq!(a.sum(Sum), 2.6);
-}
-
-#[test]
-fn self_reference() {
-    struct A(u32);
-
-    #[derive(serde::Serialize, serde::Deserialize)]
-    struct Inc;
-    #[derive(serde::Serialize, serde::Deserialize)]
-    struct Count;
-
-    #[abstract_process]
-    impl A {
-        #[init]
-        fn init(this: ProcessRef<Self>, start: u32) -> A {
-            // Start incrementing state state.
-            this.increment(Inc);
-
-            A(start)
-        }
-
-        #[process_message]
-        fn increment(&mut self, _: Inc) {
-            // Increment state until 10
-            if self.0 < 10 {
-                self.0 += 1;
-                // Increment state again
-                self.process().increment(Inc);
+        fn init(_process: ProcessRef<Self>, _arg: ()) -> Self {
+            unsafe { host::api::process::die_when_link_dies(0) };
+            spawn_link!(|| panic!());
+            Self {
+                link_trapped: false,
             }
         }
 
+        #[handle_link_trapped]
+        fn handle_link_trapped(&mut self, tag: Tag) {
+            println!("Link trapped: {:?}", tag);
+            self.link_trapped = true;
+        }
+
         #[process_request]
-        fn count(&self, _: Count) -> u32 {
-            self.0
+        fn is_link_trapped(&self) -> bool {
+            self.link_trapped
         }
     }
 
-    let a = A::start_link(0, None);
-    // Give enough time to increment state.
-    sleep(Duration::from_millis(20));
-
-    assert_eq!(a.count(Count), 10);
+    let a = A::start((), None);
+    sleep(Duration::from_millis(10));
+    assert!(a.is_link_trapped());
 }
 
 #[test]
-fn lookup() {
-    struct A;
+fn handle_zero_argument() {
+    struct Counter {
+        count: u32,
+    }
 
     #[abstract_process]
-    impl A {
+    impl Counter {
         #[init]
-        fn init(_: ProcessRef<Self>, _: ()) -> A {
-            A
+        fn init(_process: ProcessRef<Self>, count: u32) -> Self {
+            Self { count }
+        }
+
+        #[process_message]
+        fn increment(&mut self, num: u32) {
+            self.count += num;
+            self.check_count();
+        }
+
+        #[process_message]
+        fn decrement(&mut self, num: u32) {
+            self.count -= num;
+            self.check_count();
         }
 
         #[process_request]
-        fn handle(&mut self, _: ()) {}
+        fn count(&self) -> u32 {
+            self.count
+        }
+
+        fn check_count(&self) {
+            if self.count > 5 {
+                println!("count exceeded 5!");
+            }
+        }
     }
 
-    let a = A::start_link((), Some("a"));
-    drop(a);
-
-    let a = ProcessRef::<A>::lookup("a").unwrap();
-    a.handle(());
-    drop(a);
-
-    let a = ProcessRef::<A>::lookup("b");
-    assert!(a.is_none());
+    let counter = Counter::start_link(2, None);
+    counter.increment(1);
+    assert_eq!(3, counter.count());
+    counter.decrement(3);
+    assert_eq!(0, counter.count());
 }
 
 #[test]
-#[should_panic]
-fn linked_process_fails() {
+fn handle_single_argument() {
     struct A;
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    struct Panic;
+    struct Name(String);
 
     #[abstract_process]
     impl A {
@@ -267,23 +141,28 @@ fn linked_process_fails() {
         }
 
         #[process_message]
-        fn panic(&mut self, _: Panic) {
-            panic!();
+        fn say_hello(&self, message: String) {
+            assert_eq!(message, "Hello");
+        }
+
+        #[process_request]
+        fn say_hello_to(&self, name: Name) -> String {
+            format!("Hello {}", name.0)
         }
     }
 
     let a = A::start_link((), None);
-    a.link();
-    a.panic(Panic);
-    sleep(Duration::from_millis(100));
+    a.say_hello("Hello".to_owned());
+    let greeting = a.say_hello_to(Name("Mark".to_owned()));
+    assert_eq!("Hello Mark", greeting);
 }
 
 #[test]
-fn unlinked_process_doesnt_fail() {
+fn handle_more_than_one_argument() {
     struct A;
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    struct Panic;
+    struct Num(u32);
 
     #[abstract_process]
     impl A {
@@ -293,21 +172,102 @@ fn unlinked_process_doesnt_fail() {
         }
 
         #[process_message]
-        fn panic(&mut self, _: Panic) {
-            panic!();
+        fn say_hello(&self, arg1: String, arg2: bool, arg3: Num) {
+            assert_eq!(arg1, "Hello");
+            assert_eq!(arg2, false);
+            assert_eq!(arg3.0, 666);
+        }
+
+        #[process_request]
+        fn say_hello_to(&self, arg1: String, arg2: bool, arg3: Num) -> String {
+            format!("{} {} {}", arg1, arg2, arg3.0)
         }
     }
 
     let a = A::start_link((), None);
-    a.link();
-    a.unlink();
-    a.panic(Panic);
-    sleep(Duration::from_millis(100));
+    a.say_hello("Hello".to_owned(), false, Num(666));
+    let greeting = a.say_hello_to("Mark".to_owned(), true, Num(777));
+    assert_eq!("Mark true 777", greeting);
 }
 
 #[test]
-fn request_timeout() {
+fn handle_mut_types() {
     struct A;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[process_message]
+        fn one_mut_arg(&self, mut _a: String) {}
+
+        #[process_request]
+        fn two_mut_arg(&self, mut _a: String, _b: bool) -> () {}
+    }
+
+    let a = A::start_link((), None);
+    a.one_mut_arg("Hello".to_owned());
+    a.two_mut_arg("Hello".to_owned(), true);
+}
+
+#[test]
+fn handle_destructuring() {
+    struct A;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Person {
+        name: String,
+        age: u16,
+    }
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[process_message]
+        fn unpack_tuples(&self, (a, (mut b, c)): (u8, (bool, char))) {
+            assert_eq!(a, 5);
+            b = !b;
+            assert_eq!(b, true);
+            assert_eq!(c, 'a');
+        }
+
+        #[process_message]
+        fn unpack_slice(&self, [a, b, c]: [u32; 3]) {
+            assert_eq!(a, 0);
+            assert_eq!(b, 1);
+            assert_eq!(c, 2);
+        }
+
+        #[process_request]
+        fn unpack_struct(&self, Person { name, mut age }: Person) -> () {
+            assert_eq!(name, "Mark");
+            age += 1;
+            assert_eq!(age, 5);
+        }
+    }
+
+    let a = A::start_link((), None);
+    a.unpack_tuples((5, (false, 'a')));
+    a.unpack_slice([0, 1, 2]);
+    a.unpack_struct(Person {
+        name: "Mark".to_owned(),
+        age: 4,
+    });
+}
+
+#[test]
+fn reply_types() {
+    struct A;
+
+    #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    struct CustomReply;
 
     #[abstract_process]
     impl A {
@@ -317,38 +277,27 @@ fn request_timeout() {
         }
 
         #[process_request]
-        fn handle(&mut self, mut request: String) -> String {
-            sleep(Duration::from_millis(25));
-            request.push_str(" world");
-            request
+        fn empty_struct(&self) -> () {}
+
+        #[process_request]
+        fn builtin_type(&self) -> bool {
+            true
+        }
+
+        #[process_request]
+        fn nested_types(&self) -> (bool, u8) {
+            (true, 9)
+        }
+
+        #[process_request]
+        fn custom_type(&self) -> CustomReply {
+            CustomReply
         }
     }
 
     let a = A::start_link((), None);
-    let response = a.request_timeout("Hello".to_owned(), Duration::from_millis(10));
-
-    assert!(response.is_err());
-}
-
-#[test]
-fn shutdown_timeout() {
-    struct A;
-
-    #[abstract_process]
-    impl A {
-        #[init]
-        fn init(_: ProcessRef<Self>, _: ()) -> A {
-            A
-        }
-
-        #[terminate]
-        fn terminate(self) {
-            sleep(Duration::from_millis(25));
-        }
-    }
-
-    let a = A::start_link((), None);
-    let response = a.shutdown_timeout(Duration::from_millis(10));
-
-    assert!(response.is_err());
+    assert_eq!(a.empty_struct(), ());
+    assert_eq!(a.builtin_type(), true);
+    assert_eq!(a.nested_types(), (true, 9));
+    assert_eq!(a.custom_type(), CustomReply);
 }

--- a/tests/abstract_process_macro.rs
+++ b/tests/abstract_process_macro.rs
@@ -1,6 +1,6 @@
 use lunatic::{
     abstract_process, host,
-    process::{Message, ProcessRef, Request, StartProcess},
+    process::{ProcessRef, StartProcess},
     sleep, spawn_link, test, Tag,
 };
 use std::time::Duration;
@@ -130,7 +130,7 @@ fn handle_single_argument() {
     struct A;
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    struct Name(String);
+    pub struct Name(String);
 
     #[abstract_process]
     impl A {
@@ -161,7 +161,7 @@ fn handle_multiple_arguments() {
     struct A;
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    struct Num(u32);
+    pub struct Num(u32);
 
     #[abstract_process]
     impl A {
@@ -217,7 +217,7 @@ fn handle_destructuring() {
     struct A;
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    struct Person {
+    pub struct Person {
         name: String,
         age: u16,
     }
@@ -266,7 +266,7 @@ fn reply_types() {
     struct A;
 
     #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-    struct CustomReply;
+    pub struct CustomReply;
 
     #[abstract_process]
     impl A {

--- a/tests/abstract_process_macro.rs
+++ b/tests/abstract_process_macro.rs
@@ -158,7 +158,7 @@ fn handle_single_argument() {
 }
 
 #[test]
-fn handle_more_than_one_argument() {
+fn handle_multiple_arguments() {
     struct A;
 
     #[derive(serde::Serialize, serde::Deserialize)]

--- a/tests/abstract_process_macro.rs
+++ b/tests/abstract_process_macro.rs
@@ -1,9 +1,8 @@
 use lunatic::{
-    host,
+    abstract_process, host,
     process::{Message, ProcessRef, Request, StartProcess},
     sleep, spawn_link, test, Tag,
 };
-use lunatic_macros::{abstract_process, process_message, process_request};
 use std::time::Duration;
 
 #[test]

--- a/tests/abstract_process_macro.rs
+++ b/tests/abstract_process_macro.rs
@@ -1,0 +1,379 @@
+use lunatic::process::SelfReference;
+use lunatic::{
+    host,
+    process::{Message, ProcessRef, Request, StartProcess},
+    sleep, test, Tag,
+};
+use lunatic_macros::*;
+use std::time::Duration;
+
+#[derive(Debug)]
+struct Counter {
+    count: u32,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Panic;
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Inc;
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Count;
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+struct CountReply(u32);
+
+#[abstract_process]
+impl Counter {
+    #[init]
+    fn init(_process: ProcessRef<Self>, count: u32) -> Self {
+        Self { count }
+    }
+
+    #[terminate]
+    fn terminate(self) {
+        println!("Shutting down with state {}", self.count);
+    }
+
+    #[handle_link_trapped]
+    fn handle_link_trapped(&mut self, tag: Tag) {
+        println!("{:?}", tag);
+    }
+
+    #[process_message]
+    fn increment(&mut self, _: Inc) {
+        self.count += 1;
+        self.check_count();
+    }
+
+    #[process_message]
+    fn panic(&mut self, _: Panic) {
+        panic!();
+    }
+
+    #[process_request]
+    fn count(&self, _: Count) -> CountReply {
+        CountReply(self.count)
+    }
+
+    fn check_count(&self) {
+        if self.count > 5 {
+            println!("count exceeded 5!");
+        }
+    }
+}
+
+#[test]
+fn init_and_terminate() {
+    let counter = Counter::start_link(2, None);
+    counter.send(Inc);
+    counter.send(Inc);
+    counter.send(Inc);
+    counter.send(Inc);
+    dbg!(counter.request(Count));
+}
+
+#[test]
+fn handle_link_trapped() {
+    struct A;
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_process: ProcessRef<Self>, _arg: ()) -> Self {
+            unsafe { host::api::process::die_when_link_dies(0) };
+            ProcessRef::<Counter>::lookup("counter").unwrap().link();
+            Self {}
+        }
+
+        #[handle_link_trapped]
+        fn handle_link_trapped(&mut self, tag: Tag) {
+            println!("Link trapped: {:?}", tag);
+        }
+    }
+
+    let counter = Counter::start(0, Some("counter"));
+    A::start((), None);
+    counter.send(Panic);
+    sleep(Duration::from_millis(50));
+}
+
+#[test]
+fn shutdown() {
+    struct A;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[terminate]
+        fn terminate(self) {
+            println!("Exiting");
+        }
+    }
+
+    let a = A::start_link((), None);
+    a.shutdown();
+}
+
+#[test]
+fn handle_message() {
+    struct A;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[process_message]
+        fn handle(&self, message: String) {
+            assert_eq!(message, "Hello world");
+        }
+    }
+
+    let a = A::start_link((), None);
+    a.send("Hello world".to_owned());
+
+    sleep(Duration::from_millis(100));
+}
+
+#[test]
+fn handle_request() {
+    struct A;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[process_request]
+        fn handle(&mut self, mut request: String) -> String {
+            request.push_str(" world");
+            request
+        }
+    }
+
+    let a = A::start_link((), None);
+    let response = a.request("Hello".to_owned());
+
+    assert_eq!(response, "Hello world");
+}
+
+#[test]
+fn init_args() {
+    struct A(Vec<f64>);
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Add(f64);
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Sum;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, arg: Vec<f64>) -> A {
+            A(arg)
+        }
+
+        #[process_message]
+        fn add(&mut self, message: Add) {
+            self.0.push(message.0);
+        }
+
+        #[process_request]
+        fn sum(&mut self, _: Sum) -> f64 {
+            self.0.iter().sum()
+        }
+    }
+
+    let init = vec![0.1, 0.1, 0.1, 0.2];
+    let a = A::start_link(init, None);
+
+    a.send(Add(0.2));
+    a.send(Add(0.2));
+    a.send(Add(0.1));
+    a.send(Add(1.0));
+    assert_eq!(a.request(Sum), 2.0);
+    a.send(Add(0.1));
+    assert_eq!(a.request(Sum), 2.1);
+    a.send(Add(0.1));
+    assert_eq!(a.request(Sum), 2.2);
+    a.send(Add(0.3));
+    assert_eq!(a.request(Sum), 2.5);
+    a.send(Add(0.1));
+    assert_eq!(a.request(Sum), 2.6);
+}
+
+#[test]
+fn self_reference() {
+    struct A(u32);
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Inc;
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Count;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(this: ProcessRef<Self>, start: u32) -> A {
+            // Start incrementing state state.
+            this.send(Inc);
+
+            A(start)
+        }
+
+        #[process_message]
+        fn increment(&mut self, _: Inc) {
+            // Increment state until 10
+            if self.0 < 10 {
+                self.0 += 1;
+                // Increment state again
+                self.process().send(Inc);
+            }
+        }
+
+        #[process_request]
+        fn count(&self, _: Count) -> u32 {
+            self.0
+        }
+    }
+
+    let a = A::start_link(0, None);
+    // Give enough time to increment state.
+    sleep(Duration::from_millis(20));
+
+    assert_eq!(a.request(Count), 10);
+}
+
+#[test]
+fn lookup() {
+    struct A;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[process_request]
+        fn handle(&mut self, _: ()) {}
+    }
+
+    let a = A::start_link((), Some("a"));
+    drop(a);
+
+    let a = ProcessRef::<A>::lookup("a").unwrap();
+    a.request(());
+    drop(a);
+
+    let a = ProcessRef::<A>::lookup("b");
+    assert!(a.is_none());
+}
+
+#[test]
+#[should_panic]
+fn linked_process_fails() {
+    struct A;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Panic;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[process_message]
+        fn handle(&mut self, _: Panic) {
+            panic!();
+        }
+    }
+
+    let a = A::start_link((), None);
+    a.link();
+    a.send(Panic);
+    sleep(Duration::from_millis(100));
+}
+
+#[test]
+fn unlinked_process_doesnt_fail() {
+    struct A;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Panic;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[process_message]
+        fn handle(&mut self, _: Panic) {
+            panic!();
+        }
+    }
+
+    let a = A::start_link((), None);
+    a.link();
+    a.unlink();
+    a.send(Panic);
+    sleep(Duration::from_millis(100));
+}
+
+#[test]
+fn request_timeout() {
+    struct A;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[process_request]
+        fn handle(&mut self, mut request: String) -> String {
+            sleep(Duration::from_millis(25));
+            request.push_str(" world");
+            request
+        }
+    }
+
+    let a = A::start_link((), None);
+    let response = a.request_timeout("Hello".to_owned(), Duration::from_millis(10));
+
+    assert!(response.is_err());
+}
+
+#[test]
+fn shutdown_timeout() {
+    struct A;
+
+    #[abstract_process]
+    impl A {
+        #[init]
+        fn init(_: ProcessRef<Self>, _: ()) -> A {
+            A
+        }
+
+        #[terminate]
+        fn terminate(self) {
+            sleep(Duration::from_millis(25));
+        }
+    }
+
+    let a = A::start_link((), None);
+    let response = a.shutdown_timeout(Duration::from_millis(10));
+
+    assert!(response.is_err());
+}

--- a/tests/abstract_process_macro.rs
+++ b/tests/abstract_process_macro.rs
@@ -70,7 +70,7 @@ fn handle_link_trapped() {
             self.link_trapped = true;
         }
 
-        #[process_request]
+        #[handle_request]
         fn is_link_trapped(&self) -> bool {
             self.link_trapped
         }
@@ -94,19 +94,19 @@ fn handle_zero_argument() {
             Self { count }
         }
 
-        #[process_message]
+        #[handle_message]
         fn increment(&mut self, num: u32) {
             self.count += num;
             self.check_count();
         }
 
-        #[process_message]
+        #[handle_message]
         fn decrement(&mut self, num: u32) {
             self.count -= num;
             self.check_count();
         }
 
-        #[process_request]
+        #[handle_request]
         fn count(&self) -> u32 {
             self.count
         }
@@ -139,12 +139,12 @@ fn handle_single_argument() {
             A
         }
 
-        #[process_message]
+        #[handle_message]
         fn say_hello(&self, message: String) {
             assert_eq!(message, "Hello");
         }
 
-        #[process_request]
+        #[handle_request]
         fn say_hello_to(&self, name: Name) -> String {
             format!("Hello {}", name.0)
         }
@@ -170,14 +170,14 @@ fn handle_multiple_arguments() {
             A
         }
 
-        #[process_message]
+        #[handle_message]
         fn say_hello(&self, arg1: String, arg2: bool, arg3: Num) {
             assert_eq!(arg1, "Hello");
             assert_eq!(arg2, false);
             assert_eq!(arg3.0, 666);
         }
 
-        #[process_request]
+        #[handle_request]
         fn say_hello_to(&self, arg1: String, arg2: bool, arg3: Num) -> String {
             format!("{} {} {}", arg1, arg2, arg3.0)
         }
@@ -200,10 +200,10 @@ fn handle_mut_types() {
             A
         }
 
-        #[process_message]
+        #[handle_message]
         fn one_mut_arg(&self, mut _a: String) {}
 
-        #[process_request]
+        #[handle_request]
         fn two_mut_arg(&self, mut _a: String, _b: bool) -> () {}
     }
 
@@ -229,7 +229,7 @@ fn handle_destructuring() {
             A
         }
 
-        #[process_message]
+        #[handle_message]
         fn unpack_tuples(&self, (a, (mut b, c)): (u8, (bool, char))) {
             assert_eq!(a, 5);
             b = !b;
@@ -237,14 +237,14 @@ fn handle_destructuring() {
             assert_eq!(c, 'a');
         }
 
-        #[process_message]
+        #[handle_message]
         fn unpack_slice(&self, [a, b, c]: [u32; 3]) {
             assert_eq!(a, 0);
             assert_eq!(b, 1);
             assert_eq!(c, 2);
         }
 
-        #[process_request]
+        #[handle_request]
         fn unpack_struct(&self, Person { name, mut age }: Person) -> () {
             assert_eq!(name, "Mark");
             age += 1;
@@ -275,20 +275,20 @@ fn reply_types() {
             A
         }
 
-        #[process_request]
+        #[handle_request]
         fn empty_struct(&self) -> () {}
 
-        #[process_request]
+        #[handle_request]
         fn builtin_type(&self) -> bool {
             true
         }
 
-        #[process_request]
+        #[handle_request]
         fn nested_types(&self) -> (bool, u8) {
             (true, 9)
         }
 
-        #[process_request]
+        #[handle_request]
         fn custom_type(&self) -> CustomReply {
             CustomReply
         }


### PR DESCRIPTION
# Proof of Concept `abstract_process` Macro

Implemented several proc macros to simplify the code to describe `AbstractProcess` processes. The macros' error reporting is really basic right now but they work for all trait methods in `AbstractMethod`, `ProcessMessage`, and `ProcessReqest`.

All unit tests from [test/absctract_process](https://github.com/lunatic-solutions/lunatic-rs/blob/main/tests/abstract_process.rs) except `different_state_type` were successfully ported over to the new way of writing `AbstractProcess`. It is possible to allow the macros to take different state types but I think it doesn't make a lot of sense in the current syntax.

I made some updates on the pros and cons list from the original issue #42. Overall, I think the new style is working really well. It makes writing new behaviors extremely easy. I haven't benchmarked the compile time yet but I can refactor the code from [lunatic-solutions/chat](https://github.com/lunatic-solutions/chat) to the new style and see how it compares.
