### PR TITLE
Add support for arguments in `#[abstract_process]` macro

### DIFF
--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -476,9 +476,7 @@ impl Parse for Args {
         let mut args = Args::default();
         while !input.is_empty() {
             args.parse_arg(input)?;
-            if !input.is_empty() {
-                let _: Token![,] = input.parse()?;
-            }
+            let _: Option<Token![,]> = input.parse()?;
         }
         Ok(args)
     }

--- a/src/function/process.rs
+++ b/src/function/process.rs
@@ -150,7 +150,12 @@ impl<M, S> Process<M, S> {
     }
 
     /// Spawn a process on a remote node.
-    pub fn spawn_node_config<C, T>(node_id: u64, config: &ProcessConfig, capture: C, entry: fn(C, T)) -> T::Process
+    pub fn spawn_node_config<C, T>(
+        node_id: u64,
+        config: &ProcessConfig,
+        capture: C,
+        entry: fn(C, T),
+    ) -> T::Process
     where
         S: Serializer<C> + Serializer<ProtocolCapture<C>>,
         T: IntoProcess<M, S>,

--- a/src/process.rs
+++ b/src/process.rs
@@ -120,7 +120,12 @@ where
     fn start_link(arg: T::Arg, name: Option<&str>) -> ProcessRef<T>;
     fn start_link_config(arg: T::Arg, name: Option<&str>, config: &ProcessConfig) -> ProcessRef<T>;
     fn start_node(arg: T::Arg, name: Option<&str>, node: u64) -> ProcessRef<T>;
-    fn start_node_config(arg: T::Arg, name: Option<&str>, node: u64, config: &ProcessConfig) -> ProcessRef<T>;
+    fn start_node_config(
+        arg: T::Arg,
+        name: Option<&str>,
+        node: u64,
+        config: &ProcessConfig,
+    ) -> ProcessRef<T>;
 }
 
 impl<T> StartProcess<T> for T
@@ -159,7 +164,7 @@ where
         arg: <T as AbstractProcess>::Arg,
         name: Option<&str>,
         node: u64,
-        config: &ProcessConfig
+        config: &ProcessConfig,
     ) -> ProcessRef<T> {
         start::<T>(arg, name, None, Some(config), Some(node)).unwrap()
     }


### PR DESCRIPTION
This PR adds optional arguments to the `#[abstract_process]` macro.

These arguments are:
- `trait_name` - for renaming the generated trait
- `visibility` - for changing the visibility of the generated trait

The trait defaults to private, and follows the same name as the item being implemented, but with `Handler` appended.

```rust
#[abstract_process(trait_name = "MyProcessHandler", visibility = pub)]
impl MyProcess { ... }
```