### PR TITLE
Add `Eq` impl for `Process` and `ProcessRef`

### DIFF
--- a/src/function/process.rs
+++ b/src/function/process.rs
@@ -343,6 +343,9 @@ impl<M, S> PartialEq for Process<M, S> {
     }
 }
 
+/// Proccess equality comparison is an equivalance relation
+impl<M, S> Eq for Process<M, S> {}
+
 // Implement Hash explicitly to match the behavior of PartialEq
 impl<M, S> std::hash::Hash for Process<M, S> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/src/process.rs
+++ b/src/process.rs
@@ -705,6 +705,9 @@ impl<T> PartialEq for ProcessRef<T> {
     }
 }
 
+/// Proccess equality comparison is an equivalance relation
+impl<T> Eq for ProcessRef<T> {}
+
 // Implement Hash explicitly to match the behavior of PartialEq
 impl<T> std::hash::Hash for ProcessRef<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
As a follow up to #56 we define a total comparison (no floating point comparisons). Adding `Eq` marker impls allows `Process`and `ProcessRef` to be used as keys in HashMaps and HashSets.

Used the [Rust docs](https://doc.rust-lang.org/std/cmp/trait.Eq.html) terminology for the comment