### PR TITLE
Add repository url to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Bernard Kolobara <bernard@lunatic.solutions>"]
 description = "Helper library for building Rust applications that run on lunatic."
 license = "Apache-2.0/MIT"
 readme = "Readme.md"
+repository = "https://github.com/lunatic-solutions/lunatic-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
When I first came across the lunatic rust crate, it took me a while to discover that the rust api was in a separate repository from lunatic itself.

This PR should add a link on docs.rs which was previously missing.