### PR TITLE
implement getters/setters of tcp timeouts

### DIFF
--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -105,6 +105,13 @@ pub mod networking {
 
             opaque: *mut u64,
         ) -> u32;
+        pub fn tcp_peek(
+            tcp_stream_id: u64,
+            buffer: *mut u8,
+            buffer_len: usize,
+
+            opaque: *mut u64,
+        ) -> u32;
         pub fn udp_send(
             udp_socket_id: u64,
             buffer: *const u8,

--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -142,6 +142,12 @@ pub mod networking {
         pub fn get_udp_socket_broadcast(udp_socket_id: u64) -> i32;
         pub fn clone_udp_socket(udp_socket_id: u64) -> u64;
         pub fn tcp_flush(tcp_stream_id: u64, error_id: *mut u64) -> u32;
+        pub fn set_read_timeout(tcp_stream_id: u64, duration: u64) -> u32;
+        pub fn get_read_timeout(tcp_stream_id: u64) -> u64;
+        pub fn set_write_timeout(tcp_stream_id: u64, duration: u64) -> u32;
+        pub fn get_write_timeout(tcp_stream_id: u64) -> u64;
+        pub fn set_peek_timeout(tcp_stream_id: u64, duration: u64) -> u32;
+        pub fn get_peek_timeout(tcp_stream_id: u64) -> u64;
     }
 }
 

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -171,6 +171,93 @@ impl TcpStream {
         let lunatic_error = LunaticError::from(id);
         Err(Error::new(ErrorKind::Other, lunatic_error))
     }
+
+    /// Sets write timeout for TcpStream
+    ///
+    /// This method will change the timeout for everyone holding a reference to the TcpStream
+    /// Once a timeout is set, it can be removed by sending `None`
+    pub fn set_write_timeout(&mut self, duration: Option<Duration>) -> Result<()> {
+        unsafe {
+            if let code @ 1.. = host::api::networking::set_write_timeout(
+                self.id,
+                duration.map_or(u64::MAX, |d| d.as_millis() as u64),
+            ) {
+                let lunatic_error = LunaticError::from(code as u64);
+                return Err(Error::new(ErrorKind::Other, lunatic_error));
+            }
+        }
+        Ok(())
+    }
+
+    /// Gets write timeout for TcpStream
+    ///
+    /// This method retrieves the write timeout duration of the TcpStream if any
+    pub fn write_timeout(&self) -> Option<Duration> {
+        unsafe {
+            match host::api::networking::get_write_timeout(self.id) {
+                u64::MAX => None,
+                millis => Some(Duration::from_millis(millis)),
+            }
+        }
+    }
+
+    /// Sets read timeout for TcpStream
+    ///
+    /// This method will change the timeout for everyone holding a reference to the TcpStream
+    /// Once a timeout is set, it can be removed by sending `None`
+    pub fn set_read_timeout(&mut self, duration: Option<Duration>) -> Result<()> {
+        unsafe {
+            if let code @ 1.. = host::api::networking::set_read_timeout(
+                self.id,
+                duration.map_or(u64::MAX, |d| d.as_millis() as u64),
+            ) {
+                let lunatic_error = LunaticError::from(code as u64);
+                return Err(Error::new(ErrorKind::Other, lunatic_error));
+            }
+        }
+        Ok(())
+    }
+
+    /// Gets read timeout for TcpStream
+    ///
+    /// This method retrieves the read timeout duration of the TcpStream if any
+    pub fn read_timeout(&self) -> Option<Duration> {
+        unsafe {
+            match host::api::networking::get_read_timeout(self.id) {
+                u64::MAX => None,
+                millis => Some(Duration::from_millis(millis)),
+            }
+        }
+    }
+
+    /// Sets peek timeout for TcpStream
+    ///
+    /// This method will change the timeout for everyone holding a reference to the TcpStream
+    /// Once a timeout is set, it can be removed by sending `None`
+    pub fn set_peek_timeout(&mut self, duration: Option<Duration>) -> Result<()> {
+        unsafe {
+            if let code @ 1.. = host::api::networking::set_peek_timeout(
+                self.id,
+                duration.map_or(u64::MAX, |d| d.as_millis() as u64),
+            ) {
+                let lunatic_error = LunaticError::from(code as u64);
+                return Err(Error::new(ErrorKind::Other, lunatic_error));
+            }
+        }
+        Ok(())
+    }
+
+    /// Gets peek timeout for TcpStream
+    ///
+    /// This method retrieves the peek timeout duration of the TcpStream if any
+    pub fn peek_timeout(&self) -> Option<Duration> {
+        unsafe {
+            match host::api::networking::get_peek_timeout(self.id) {
+                u64::MAX => None,
+                millis => Some(Duration::from_millis(millis)),
+            }
+        }
+    }
 }
 
 impl Write for TcpStream {

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -318,7 +318,6 @@ impl Write for TcpStream {
         let mut error_id = 0;
         match unsafe { host::api::networking::tcp_flush(self.id, &mut error_id as *mut u64) } {
             0 => Ok(()),
-            TIMEOUT => Err(Error::new(ErrorKind::TimedOut, "TcpStream flush timed out")),
             _ => {
                 let lunatic_error = LunaticError::from(error_id);
                 Err(Error::new(ErrorKind::Other, lunatic_error))


### PR DESCRIPTION
A revised version of the tcp timeouts. Now we're just calling the host functions that handle saving the timeouts