### PR TITLE
Manually implement `Clone` and `Copy` on `Mailbox`

### DIFF
--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -42,7 +42,6 @@ pub struct Catching;
 /// returned [`Mailbox<_, _, Catching>`] will receive a special
 /// [`MailboxResult::LinkDied`] in its mailbox containing the [`Tag`] used when
 /// the process was spawned ([`spawn_link_tag`](Process::spawn_link_tag)).
-#[derive(Debug, Clone, Copy)]
 pub struct Mailbox<M, S = Bincode, L = ()>
 where
     S: Serializer<M>,
@@ -188,6 +187,19 @@ where
         }
     }
 }
+
+impl<S, M, L> Clone for Mailbox<M, S, L>
+where
+    S: Serializer<M>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            phantom: self.phantom,
+        }
+    }
+}
+
+impl<S, M, L> Copy for Mailbox<M, S, L> where S: Serializer<M> {}
 
 /// Result of a `recieve*` call on a [`Mailbox`].
 #[derive(Debug)]


### PR DESCRIPTION
- Manually implements `Clone` and `Copy` on `Mailbox`.
- Removes `Debug` derive, since no valuable information is printed (just `Mailbox { phantom: PhantomData }`).

The `#[derive(Clone, Copy)]` macros force any generics to also be `Clone`, `Copy` in the implementation. But the mailbox is just phantom data, we can manually implement clone and copy to prevent the `M` message and `S` serializer from having that requirement.