### PR TITLE
Recursive protocols

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -182,12 +182,6 @@ impl<P, S, Z> Protocol<Rec<P>, S, Z>
     /// Repeat Protocol
     #[must_use]
     pub fn repeat(self) -> Protocol<P, S, Protocol<Rec<P>, S, Z>> {
-        /*let copy = Self {
-            id: self.id,
-            node_id: self.node_id,
-            tag: self.tag,
-            phantom: self.phantom,
-        };*/
         self.cast()
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -39,7 +39,7 @@ impl<P: 'static, S> Drop for Protocol<P, S> {
         if TypeId::of::<P>() != TypeId::of::<End>() && TypeId::of::<P>() != TypeId::of::<TaskEnd>()
         {
             panic!(
-                "Protocol prematurely dropped, before reaching the `End`, `TaskEnd`, or `Rec<>` state (currently: {}).",
+                "Protocol prematurely dropped, before reaching the `End` or `TaskEnd` state (currently: {}).",
                 std::any::type_name::<P>()
             );
         }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,10 +1,12 @@
-use lunatic::protocol::{End, Protocol, Send};
 use lunatic::Process;
 use lunatic_test::test;
 
 #[test]
 #[should_panic]
 fn drop_unfinished() {
+    use lunatic::protocol::End;
+    use lunatic::protocol::Protocol;
+    use lunatic::protocol::Send;
     let protocol = Process::spawn_link((), |_, _: Protocol<Send<(), End>>| {
         // Protocol dropped without sending a message back.
     });
@@ -16,6 +18,9 @@ fn drop_unfinished() {
 fn msg_pack_serializer() {
     use lunatic::protocol::Recv;
     use lunatic::serializer::MessagePack;
+    use lunatic::protocol::End;
+    use lunatic::protocol::Protocol;
+    use lunatic::protocol::Send;
 
     let protocol = Process::spawn_link(
         (),
@@ -29,4 +34,35 @@ fn msg_pack_serializer() {
     let protocol = protocol.send(input);
     let (_, result) = protocol.receive();
     assert_eq!(0.88, result);
+}
+
+#[test]
+fn recursive_protocols() {
+    use lunatic::protocol::Rec;
+    use lunatic::protocol::Recv;
+    use lunatic::protocol::Send;
+    use lunatic::protocol::End;
+    use lunatic::protocol::Protocol;
+    type P = Recv<u64, Send<u64, End>>;
+
+    let protocol = Process::spawn_link(
+        (),
+        |(), proto: Protocol<Rec<P>>| {
+
+            loop {
+                let loop_protocol = proto.repeat();
+                let (protocol, v) = loop_protocol.receive();
+                let _end = protocol.send(v * 2);
+            }
+        }
+    );
+
+    for i in 0..5 {
+        let loop_protocol = protocol.repeat();
+        let p = loop_protocol.send(i);
+        let (_end, value) = p.receive();
+        assert_eq!(i * 2, value);
+    }
+
+    let _end = protocol.end();
 }


### PR DESCRIPTION
I'm not really a fan of the close() call, but it seemed the most reasonable approach, especially cause it lets the process live forever.
I could make Rec<P> be essentially a special version of Offer<P, End>, making the repeat / close calls the left/right branches.
Any other ideas? Struggling to get this to be really nice from an API pov.

Even more preferable would be a way to make the `End`s inside of Rec<P> reference P somehow again, which would allow the P inside of Rec decide when the loop may end, but I haven't really figured out how this could work either.