### PR TITLE
Remove serde bounds for ProcessRef

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -413,6 +413,7 @@ where
 /// messages of different types, as long as the traits `MessageHandler<M>` or
 /// `RequestHandler<R>` are implemented for T.
 #[derive(serde::Serialize, serde::Deserialize)]
+#[serde(bound = "")]
 pub struct ProcessRef<T>
 where
     T: ?Sized,


### PR DESCRIPTION
Removes the automatic bounds for the generic `T` in `ProcessRef<T>`.