### PR TITLE
Put tasks into closures

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -171,7 +171,7 @@ macro_rules! spawn_link {
             $(&$config,)?
             (),
             |_, protocol: lunatic::protocol::Protocol<lunatic::protocol::Send<_,lunatic::protocol::TaskEnd>>| {
-                let _ = protocol.send($body);
+                let _ = protocol.send((move || $body)());
             },
         )
     };
@@ -185,7 +185,7 @@ macro_rules! spawn_link {
                 ($($argument),*),
                 |($($argument),*), protocol: lunatic::protocol::Protocol<
                         lunatic::protocol::Send<_,lunatic::protocol::TaskEnd>>| {
-                    let _ = protocol.send($body);
+                    let _ = protocol.send((move || $body)());
                 },
             )
         }
@@ -199,7 +199,7 @@ macro_rules! spawn_link {
                 ($($argument),*),
                 |($($argument),*), protocol: lunatic::protocol::Protocol<
                         lunatic::protocol::Send<_,lunatic::protocol::TaskEnd>>| {
-                    let _ = protocol.send($body);
+                    let _ = protocol.send((move || $body)());
                 },
             )
         }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -104,6 +104,21 @@ fn task() {
     let b = "world".to_owned();
     let task = spawn_link!(@task |a, b| format!("{} {}",a, b));
     assert_eq!(task.result(), "hello world");
+
+    let task = spawn_link!(@task || {
+        let err = Err(());
+        err?;
+        Ok(())
+    });
+    assert_eq!(task.result(), Err(()));
+
+    let task = spawn_link!(@task |a = 2, b = 3| {
+        if a == 2 {
+            return 0;
+        }
+        a + b
+    });
+    assert_eq!(task.result(), 0);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #84

Adds support for return keyword, and `?` operator in `spawn_link!(@task ...)`.