### PR TITLE
Add mut to captured variables in macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -53,7 +53,7 @@ macro_rules! spawn {
             lunatic::spawn_link_config!($($config)?) (
                 $(&$config,)?
                 ($($argument),*),
-                |($($argument),*), _: lunatic::Mailbox<()>| $body
+                |($(mut $argument),*), _: lunatic::Mailbox<()>| $body
             )
         }
     };
@@ -64,7 +64,7 @@ macro_rules! spawn {
             lunatic::spawn_link_config!($($config)?) (
                 $(&$config,)?
                 ($($argument),*),
-                |($($argument),*), _: lunatic::Mailbox<()>| $body
+                |($(mut $argument),*), _: lunatic::Mailbox<()>| $body
             )
         }
     };
@@ -81,7 +81,7 @@ macro_rules! spawn {
         lunatic::spawn_link_config!($($config)?) (
             $(&$config,)?
             $argument,
-            |$argument, $mailbox: lunatic::Mailbox<$mailbox_ty $( , $mailbox_s )?>| $body,
+            |mut $argument, $mailbox: lunatic::Mailbox<$mailbox_ty $( , $mailbox_s )?>| $body,
         )
     };
 }
@@ -133,7 +133,7 @@ macro_rules! spawn_link {
             lunatic::spawn_link_config!(@link $($config)?) (
                 $(&$config,)?
                 ($($argument),*),
-                |($($argument),*), _: lunatic::Mailbox<()>| $body
+                |($(mut $argument),*), _: lunatic::Mailbox<()>| $body
             )
         }
     };
@@ -144,7 +144,7 @@ macro_rules! spawn_link {
             lunatic::spawn_link_config!(@link $($config)?) (
                 $(&$config,)?
                 ($($argument),*),
-                |($($argument),*), _: lunatic::Mailbox<()>| $body
+                |($(mut $argument),*), _: lunatic::Mailbox<()>| $body
             )
         }
     };
@@ -161,7 +161,7 @@ macro_rules! spawn_link {
         lunatic::spawn_link_config!(@link $($config)?) (
             $(&$config,)?
             $argument,
-            |$argument, $mailbox: lunatic::Mailbox<$mailbox_ty $( , $mailbox_s )?>| $body,
+            |mut $argument, $mailbox: lunatic::Mailbox<$mailbox_ty $( , $mailbox_s )?>| $body,
         )
     };
 
@@ -183,7 +183,7 @@ macro_rules! spawn_link {
             lunatic::spawn_link_config!(@link $($config)?) (
                 $(&$config,)?
                 ($($argument),*),
-                |($($argument),*), protocol: lunatic::protocol::Protocol<
+                |($(mut $argument),*), protocol: lunatic::protocol::Protocol<
                         lunatic::protocol::Send<_,lunatic::protocol::TaskEnd>>| {
                     let _ = protocol.send((move || $body)());
                 },
@@ -197,7 +197,7 @@ macro_rules! spawn_link {
             lunatic::spawn_link_config!(@link $($config)?) (
                 $(&$config,)?
                 ($($argument),*),
-                |($($argument),*), protocol: lunatic::protocol::Protocol<
+                |($(mut $argument),*), protocol: lunatic::protocol::Protocol<
                         lunatic::protocol::Send<_,lunatic::protocol::TaskEnd>>| {
                     let _ = protocol.send((move || $body)());
                 },
@@ -218,7 +218,7 @@ macro_rules! spawn_link {
         lunatic::spawn_link_config!(@link $($config)?) (
             $(&$config,)?
             $argument,
-            |$argument, $protocol: lunatic::protocol::Protocol<$proto_ty>| $body,
+            |mut $argument, $protocol: lunatic::protocol::Protocol<$proto_ty>| $body,
         )
     };
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -15,6 +15,11 @@ fn spawn() {
     // Capture local var & mailbox process
     let local_var = "Hello".to_owned();
     spawn!(|local_var, _mailbox: Mailbox<()>| assert_eq!(local_var, "Hello"));
+    // Modify local var
+    let local_var = "Hello".to_owned();
+    spawn!(|local_var| {
+        local_var.push_str(", world");
+    });
 }
 
 #[test]
@@ -35,6 +40,11 @@ fn spawn_config() {
         local_var,
         "Hello"
     ));
+    // Modify local var
+    let local_var = "Hello".to_owned();
+    spawn!(&config, |local_var| {
+        local_var.push_str(", world");
+    });
 }
 
 #[test]
@@ -49,6 +59,11 @@ fn spawn_link() {
     // Capture local var & mailbox process
     let local_var = "Hello".to_owned();
     spawn_link!(|local_var, _mailbox: Mailbox<()>| assert_eq!(local_var, "Hello"));
+    // Modify local var
+    let local_var = "Hello".to_owned();
+    spawn_link!(|local_var| {
+        local_var.push_str(", world");
+    });
 
     // Protocol, no capture
     spawn_link!(|_proto: Protocol<End>| {});
@@ -73,6 +88,11 @@ fn spawn_link_config() {
         local_var,
         "Hello"
     ));
+    // Modify local var
+    let local_var = "Hello".to_owned();
+    spawn_link!(&config, |local_var| {
+        local_var.push_str(", world");
+    });
 
     // Protocol, no capture
     spawn_link!(&config, |_proto: Protocol<End>| {});
@@ -105,6 +125,13 @@ fn task() {
     let task = spawn_link!(@task |a, b| format!("{} {}",a, b));
     assert_eq!(task.result(), "hello world");
 
+    let a = "Hello".to_owned();
+    let task = spawn_link!(@task |a| {
+        a.push_str(", world");
+        a
+    });
+    assert_eq!(task.result(), "Hello, world");
+
     let task = spawn_link!(@task || {
         let err = Err(());
         err?;
@@ -128,13 +155,20 @@ fn task_config() {
     let task = spawn_link!(@task &config, || 33);
     assert_eq!(task.result(), 33);
 
-    let task = spawn_link!(@task  &config, |a = 2, b = 3| a + b);
+    let task = spawn_link!(@task &config, |a = 2, b = 3| a + b);
     assert_eq!(task.result(), 5);
 
     let a = "hello".to_owned();
     let b = "world".to_owned();
     let task = spawn_link!(@task &config, |a, b| format!("{} {}",a, b));
     assert_eq!(task.result(), "hello world");
+
+    let a = "Hello".to_owned();
+    let task = spawn_link!(@task &config, |a| {
+        a.push_str(", world");
+        a
+    });
+    assert_eq!(task.result(), "Hello, world");
 }
 
 #[test]


### PR DESCRIPTION
Previously, you could not mutate captured variables when using the `spawn!` and `spawn_link!` macros.
```rust
let msg = "Hello".to_string();
spawn_link!(|msg| {
    msg.push_str(", world"); // Fails
});
```

This PR adds support for this by adding `mut` before each variable when expanded.