### PR TITLE
Add `AbstractMessage` derive macro and `Request` type

### DIFF
--- a/lunatic-macros/Cargo.toml
+++ b/lunatic-macros/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0/MIT"
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0"
-convert_case = "0.5"
+convert_case = "0.6"
 
 [lib]
 proc-macro = true

--- a/lunatic-macros/src/abstract_message.rs
+++ b/lunatic-macros/src/abstract_message.rs
@@ -1,0 +1,188 @@
+use convert_case::{Case, Casing};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::{
+    AngleBracketedGenericArguments, Data, DeriveInput, Fields, GenericArgument, Ident,
+    PathArguments, Result, Type, Variant,
+};
+
+pub struct DeriveAbstractMessage {
+    ident: Ident,
+    messages: Vec<Message>,
+}
+
+#[derive(Debug)]
+struct Message {
+    name: Ident,
+    params: Params,
+    reply_param: Option<(usize, Type)>,
+}
+
+#[derive(Debug)]
+enum Params {
+    Named(Vec<(Ident, Type)>),
+    Unnamed(Vec<(Ident, Type)>),
+    Unit,
+}
+
+impl Params {
+    fn items(&self) -> &[(Ident, Type)] {
+        match self {
+            Params::Named(named) => named,
+            Params::Unnamed(unnamed) => unnamed,
+            Params::Unit => &[],
+        }
+    }
+
+    fn expand_params(&self, ident: &Ident, variant: &Ident) -> TokenStream {
+        let params = self.items().iter().map(|(ident, _)| ident);
+
+        match self {
+            Params::Named(_) => {
+                quote! {
+                    #ident::#variant { #( #params ),* }
+                }
+            }
+            Params::Unnamed(_) => {
+                quote! {
+                    #ident::#variant( #( #params ),* )
+                }
+            }
+            Params::Unit => quote! {
+                #ident::#variant
+            },
+        }
+    }
+}
+
+impl From<Variant> for Message {
+    fn from(variant: Variant) -> Self {
+        let name = variant.ident;
+        let params = match variant.fields {
+            Fields::Named(named) => Params::Named(
+                named
+                    .named
+                    .into_iter()
+                    .map(|field| (field.ident.unwrap(), field.ty))
+                    .collect(),
+            ),
+            Fields::Unnamed(unnamed) => Params::Unnamed(
+                unnamed
+                    .unnamed
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, field)| (format_ident!("arg{i}"), field.ty))
+                    .collect(),
+            ),
+            Fields::Unit => {
+                return Message {
+                    name,
+                    params: Params::Unit,
+                    reply_param: None,
+                }
+            }
+        };
+
+        let reply_param = params
+            .items()
+            .iter()
+            .enumerate()
+            .find_map(|(i, (_, ty))| get_request_ty(ty).map(|ty| (i, ty.clone())));
+
+        Message {
+            name,
+            params,
+            reply_param,
+        }
+    }
+}
+
+impl Parse for DeriveAbstractMessage {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let input: DeriveInput = input.parse()?;
+        let ident = input.ident;
+        let messages = match input.data {
+            Data::Enum(data) => data.variants.into_iter().map(From::from).collect(),
+            _ => unimplemented!("only enums are supported"),
+        };
+
+        Ok(DeriveAbstractMessage { ident, messages })
+    }
+}
+
+impl ToTokens for DeriveAbstractMessage {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self { ident, messages } = self;
+
+        let methods = messages.iter().map(|message| {
+            let method_ident = format_ident!("{}", message.name.to_string().to_case(Case::Snake));
+            let params = message.params.items().iter().enumerate().filter_map(|(i, (param_ident, param_ty))| {
+                let is_reply_param = message.reply_param.as_ref().map(|(reply_param_index, _)| reply_param_index == &i).unwrap_or(false);
+                if is_reply_param {
+                    return None;
+                }
+
+                Some(quote! { #param_ident: #param_ty })
+            });
+
+            let message_expanded = message.params.expand_params(ident, &message.name);
+
+            match &message.reply_param {
+                None => {
+                    quote! {
+                        pub fn #method_ident(process: ::lunatic::Process<#ident> #( , #params )*) {
+                            process.send(#message_expanded)
+                        }
+                    }
+                },
+                Some((i, ty)) => {
+                    let request_ident = &message.params.items().get(*i).unwrap().0;
+                    quote! {
+                        pub fn #method_ident(process: ::lunatic::Process<#ident> #( , #params )*) -> #ty {
+                            let #request_ident = ::lunatic::Request::new();
+                            process.send(#message_expanded);
+                            #request_ident.wait()
+                        }
+                    }
+                },
+            }
+        });
+
+        tokens.extend(quote! {
+            impl #ident {
+                #( #methods )*
+            }
+        });
+    }
+}
+
+fn get_request_ty(ty: &Type) -> Option<&Type> {
+    match ty {
+        Type::Path(path) => {
+            let path_str = path.path.to_token_stream().to_string().replace(' ', "");
+            let path_str = path_str
+                .split_once('<')
+                .map(|(s, _)| s)
+                .unwrap_or(&path_str);
+            let is_request = matches!(path_str, "Request" | "lunatic::Request");
+            if !is_request {
+                return None;
+            }
+
+            let last_segment = path.path.segments.last()?;
+            let PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) = &last_segment.arguments else {
+                return None;
+            };
+            if args.len() > 1 {
+                return None;
+            }
+            let GenericArgument::Type(arg) = args.first()? else {
+                return None;
+            };
+
+            Some(arg)
+        }
+        _ => None,
+    }
+}

--- a/lunatic-macros/src/lib.rs
+++ b/lunatic-macros/src/lib.rs
@@ -1,8 +1,12 @@
 #[allow(unused_extern_crates)]
 extern crate proc_macro;
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
+use syn::parse_macro_input;
 
+use crate::abstract_message::DeriveAbstractMessage;
+
+mod abstract_message;
 mod abstract_process;
 
 /// Marks the main function to be executed by the lunatic runtime as the root
@@ -173,6 +177,12 @@ pub fn abstract_process(args: TokenStream, item: TokenStream) -> TokenStream {
         Ok(abstract_process) => abstract_process.expand().into(),
         Err(err) => err.into_compile_error().into(),
     }
+}
+
+#[proc_macro_derive(AbstractMessage)]
+pub fn abstract_message(input: TokenStream) -> TokenStream {
+    let root = parse_macro_input!(input as DeriveAbstractMessage);
+    TokenStream::from(root.into_token_stream())
 }
 
 fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenStream {

--- a/tests/abstract_message.rs
+++ b/tests/abstract_message.rs
@@ -1,0 +1,40 @@
+use lunatic::{test, AbstractMessage, Mailbox, Process, Request};
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn abstract_message() {
+    #[derive(AbstractMessage, Serialize, Deserialize)]
+    pub enum CounterMessage {
+        Increment { amount: u32 },
+        Decrement { amount: u32 },
+        Count(Request<i64>),
+    }
+
+    fn counter_process((): (), mailbox: Mailbox<CounterMessage>) {
+        // State
+        let mut count = 0;
+
+        loop {
+            match mailbox.receive() {
+                CounterMessage::Increment { amount } => {
+                    count += amount as i64;
+                }
+                CounterMessage::Decrement { amount } => {
+                    count -= amount as i64;
+                }
+                CounterMessage::Count(request) => {
+                    request.reply(count);
+                }
+            }
+        }
+    }
+
+    let counter = Process::spawn((), counter_process);
+    assert_eq!(CounterMessage::count(counter), 0);
+    CounterMessage::increment(counter, 5);
+    assert_eq!(CounterMessage::count(counter), 5);
+    CounterMessage::increment(counter, 20);
+    assert_eq!(CounterMessage::count(counter), 25);
+    CounterMessage::decrement(counter, 50);
+    assert_eq!(CounterMessage::count(counter), -25);
+}


### PR DESCRIPTION
This PR proposes a new derive macro called `AbstractMessage` as a replacement for `AbstractProcess`.
Instead of focusing on the state of a process, `AbstractMessage` focuses on providing convenient methods for interacting with a process using an enum message.

The `AbstractMessage` macro generates a method for each variant in the given enum. If the enum contains a (named or unnamed) field `Request<T>`, that message is treated as a request and will wait for a reply.

```rust
#[derive(AbstractMessage, Serialize, Deserialize)]
pub enum CounterMessage {
    Increment { amount: u32 },
    Decrement { amount: u32 },
    Count(Request<i64>), // Derive macro detects this is a "request" since it contains the `Request` in the variant
}

fn counter_process((): (), mailbox: Mailbox<CounterMessage>) {
    // State
    let mut count = 0;

    loop {
        match mailbox.receive() {
            CounterMessage::Increment { amount } => {
                count += amount as i64;
            }
            CounterMessage::Decrement { amount } => {
                count -= amount as i64;
            }
            CounterMessage::Count(request) => {
                request.reply(count);
            }
        }
    }
}

let counter = Process::spawn((), counter_process);

CounterMessage::increment(counter, 5);
CounterMessage::increment(counter, 3);

let count = CounterMessage::count(counter);
assert_eq!(count, 2);
```

The generated implementation:

```rust
// generated from derive macro
impl CounterMessage {
    pub fn increment(process: ::lunatic::Process<CounterMessage>, amount: u32) {
        process.send(CounterMessage::Increment { amount })
    }
    pub fn decrement(process: ::lunatic::Process<CounterMessage>, amount: u32) {
        process.send(CounterMessage::Decrement { amount })
    }
    pub fn count(process: ::lunatic::Process<CounterMessage>) -> i64 {
        let arg0 = ::lunatic::Request::new();
        process.send(CounterMessage::Count(arg0));
        arg0.wait()
    }
}
```

*A test can be seen here: <https://github.com/lunatic-solutions/lunatic-rs/pull/94/files#diff-d450a90b65c40970215e4a7c13162ac459d7fbaf2825ba985ccffae459ebc975>*

### Advantages of `AbstractMessage` over `AbstractProcess`

- Uses normal processes with a simple abstraction.
- Supports exporting to a .wasm file.
- The generated code is minimal and only includes implementations, not traits.
- It is easy to add support for choosing a serializer. The trait can automatically detect the serializer if it is specified in the code with `Request<T, Json>`, and it can be different for each message.

### Downsides

- `AbstractMessage` is still a macro and still generates code.
- All messages must be defined in a single enum, so you cannot implement messages from another crate. However, it would be easy to create a wrapper type to work around this limitation.

Please note that this is a draft and is mostly here to look for feedback and suggestions.