### PR TITLE
Add peer_addr method for TCP and UDP

### DIFF
--- a/src/host/api.rs
+++ b/src/host/api.rs
@@ -76,6 +76,8 @@ pub mod networking {
         pub fn tcp_local_addr(tcp_listener_id: u64, addr_dns_iter: *mut u64) -> u32;
         pub fn tls_local_addr(tcp_listener_id: u64, addr_dns_iter: *mut u64) -> u32;
         pub fn udp_local_addr(udp_socket_id: u64, addr_dns_iter: *mut u64) -> u32;
+        pub fn tcp_peer_addr(tcp_stream_id: u64, addr_dns_iter: *mut u64) -> u32;
+        pub fn udp_peer_addr(udp_stream_id: u64, addr_dns_iter: *mut u64) -> u32;
         pub fn tcp_accept(listener_id: u64, id: *mut u64, peer_dns_iter: *mut u64) -> u32;
         pub fn tcp_connect(
             addr_type: u32,

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,3 +1,6 @@
+use std::io::ErrorKind;
+use std::net::IpAddr;
+
 use lunatic::net;
 use lunatic_test::test;
 
@@ -76,6 +79,25 @@ fn udp_ping_receiver_clone() {
 
     assert_eq!(len_in, 4);
     assert_eq!(buf, "P1NG".as_bytes());
+}
+
+#[test]
+fn udp_peer_addr() {
+    let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let receiver = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let receiver_addr = receiver.local_addr().unwrap();
+
+    assert_eq!(
+        sender.peer_addr().unwrap_err().kind(),
+        ErrorKind::NotConnected
+    );
+
+    sender.connect(receiver_addr).expect("couldn't connect");
+
+    assert_eq!(
+        sender.peer_addr().unwrap().ip(),
+        IpAddr::from([127, 0, 0, 1])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Add missing `peer_addr` method to `TcpStream` and `UdpSocket`

- Added tests for `UdpSocket`

[Corresponding PR for VM](https://github.com/lunatic-solutions/lunatic/pull/169)