### PR TITLE
Use fully qualified paths for abstract_process macro

### DIFF
--- a/lunatic-macros/src/abstract_process.rs
+++ b/lunatic-macros/src/abstract_process.rs
@@ -300,7 +300,7 @@ impl AbstractProcess {
         let arg_ty = &self.arg_ty;
 
         quote! {
-            fn init(this: ProcessRef<Self>, arg: #arg_ty) -> Self::State {
+            fn init(this: lunatic::process::ProcessRef<Self>, arg: #arg_ty) -> Self::State {
                 Self::#ident(this, arg)
             }
         }
@@ -640,7 +640,7 @@ impl AbstractProcess {
             }
 
             impl #impl_generics #message_builder_ident #ty_generics #where_clause {
-                fn new(duration: std::time::Duration, process_ref: ProcessRef<#self_ty>) -> Self {
+                fn new(duration: std::time::Duration, process_ref: lunatic::process::ProcessRef<#self_ty>) -> Self {
                     Self {
                         duration,
                         process_ref,
@@ -656,7 +656,7 @@ impl AbstractProcess {
             }
 
             impl #impl_generics #request_builder_ident #ty_generics #where_clause {
-                fn new(duration: std::time::Duration, process_ref: ProcessRef<#self_ty>) -> Self {
+                fn new(duration: std::time::Duration, process_ref: lunatic::process::ProcessRef<#self_ty>) -> Self {
                     Self {
                         duration,
                         process_ref,

--- a/tests/abstract_process.rs
+++ b/tests/abstract_process.rs
@@ -390,3 +390,37 @@ fn shutdown_timeout() {
 
     assert!(response.is_timed_out());
 }
+
+// Tests macro works with no use statements
+mod no_imports_test {
+
+    struct Counter(u32);
+
+    #[lunatic::abstract_process]
+    impl Counter {
+        #[init]
+        fn init(_: lunatic::process::ProcessRef<Self>, start: u32) -> Self {
+            Self(start)
+        }
+
+        #[terminate]
+        fn terminate(self) {
+            println!("Shutdown process");
+        }
+
+        #[handle_link_trapped]
+        fn handle_link_trapped(&self, _tag: lunatic::Tag) {
+            println!("Link trapped");
+        }
+
+        #[handle_message]
+        fn increment(&mut self) {
+            self.0 += 1;
+        }
+
+        #[handle_request]
+        fn count(&self) -> u32 {
+            self.0
+        }
+    }
+}

--- a/tests/abstract_process.rs
+++ b/tests/abstract_process.rs
@@ -393,7 +393,6 @@ fn shutdown_timeout() {
 
 // Tests macro works with no use statements
 mod no_imports_test {
-
     struct Counter(u32);
 
     #[lunatic::abstract_process]


### PR DESCRIPTION
Previously the abstract_process macro required `ProcessRef` to be available in scope.

This PR fixes this, and adds a test to cover this case.