### PR TITLE
Move `call_host_alloc` into `host` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@ pub use module::{Param, WasmModule};
 #[doc(hidden)]
 pub use process_local::statik::Key as __StaticProcessLocalInner;
 pub use process_local::ProcessLocal;
-use serde::Deserialize;
 pub use tag::Tag;
 
 /// Implemented for all resources held by the VM.
@@ -153,28 +152,4 @@ pub trait Resource {
 /// Suspends the current process for `duration` of time.
 pub fn sleep(duration: std::time::Duration) {
     unsafe { host::api::process::sleep_ms(duration.as_millis() as u64) };
-}
-
-/// Utility for calling an allocating host function which is deserialized into
-/// `T`.
-///
-/// # Example
-///
-/// ```no_run
-/// struct Foo { a: String }
-///
-/// let foo = call_host_alloc::<Foo>(|len_ptr| unsafe {
-///     lunatic::host::some_allocating_fn(len_ptr)
-/// }).unwrap();
-/// ```
-#[doc(hidden)]
-pub fn call_host_alloc<T>(f: impl Fn(*mut u32) -> u32) -> bincode::Result<T>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let mut len = 0_u32;
-    let len_ptr = &mut len as *mut u32;
-    let ptr = f(len_ptr);
-    let data_vec = unsafe { Vec::from_raw_parts(ptr as *mut u8, len as usize, len as usize) };
-    bincode::deserialize(&data_vec)
 }

--- a/src/sqlite/error.rs
+++ b/src/sqlite/error.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::client::SqliteClient;
-use crate::call_host_alloc;
+use crate::host::call_host_alloc;
 
 /// An Sqlite error with a code and optional message.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/sqlite/query.rs
+++ b/src/sqlite/query.rs
@@ -4,7 +4,7 @@ use lunatic_sqlite_api::wire_format::{BindKey, BindList, BindPair, SqliteRow};
 use super::client::SqliteClient;
 use super::error::{SqliteCode, SqliteError, SqliteErrorExt};
 use super::value::Value;
-use crate::call_host_alloc;
+use crate::host::call_host_alloc;
 
 /// Trait for querying data and executing queries.
 pub trait Query {


### PR DESCRIPTION
The `call_host_alloc` is better placed in the `host` module.