### PR TITLE
Implement Debug for Protocol manually with generics

### DIFF
--- a/src/function/process.rs
+++ b/src/function/process.rs
@@ -245,12 +245,12 @@ impl<M, S> Process<M, S> {
         T::spawn(capture, entry, Some(tag), Some(config), None)
     }
 
-    /// Returns a local node process ID.
+    /// Returns the process ID for the local node.
     pub fn id(&self) -> u64 {
         self.id
     }
 
-    /// Returns a node ID.
+    /// Returns the node ID.
     pub fn node_id(&self) -> u64 {
         self.node_id
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,7 +1,7 @@
-use std::any::TypeId;
-use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::time::Duration;
+use std::{any, marker::PhantomData};
+use std::{any::TypeId, fmt};
 
 use crate::function::process::IntoProcess;
 use crate::serializer::{Bincode, CanSerialize};
@@ -26,7 +26,7 @@ pub struct ProtocolCapture<C> {
 /// It uses session types to check during compile time that all messages
 /// exchanged between two processes are in the correct order and of the correct
 /// type.
-#[derive(Debug, Hash)]
+#[derive(Hash)]
 pub struct Protocol<P: 'static, S = Bincode, Z: 'static = ()> {
     id: u64,
     node_id: u64,
@@ -196,6 +196,19 @@ impl<P2, S, Z> Protocol<Pop, S, Protocol<P2, S, Z>> {
 impl<P, S, Z> From<Protocol<Rec<P>, S, Z>> for Protocol<P, S, Z> {
     fn from(p: Protocol<Rec<P>, S, Z>) -> Self {
         p.cast()
+    }
+}
+
+impl<P, S, Z> fmt::Debug for Protocol<P, S, Z> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Protocol")
+            .field("id", &self.id)
+            .field("node_id", &self.node_id)
+            .field("tag", &self.tag)
+            .field("protocol", &any::type_name::<P>())
+            .field("serializer", &any::type_name::<S>())
+            .field("Z", &any::type_name::<Z>())
+            .finish()
     }
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -47,10 +47,20 @@ impl<P: 'static, S, Z: 'static> Drop for Protocol<P, S, Z> {
 }
 
 impl<P, S, Z> Protocol<P, S, Z> {
-    /// Turn a process into a protocol
-    fn from_process<M, S2>(process: Process<M, S2>, tag: Tag) -> Self {
-        // The transformation shouldn't drop the process resource.
-        let process = ManuallyDrop::new(process);
+    /// Returns the process ID for the local node.
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Returns the node ID.
+    pub fn node_id(&self) -> u64 {
+        self.node_id
+    }
+
+    /// Returns the protocol tag.
+    pub fn tag(&self) -> Tag {
+        self.tag
+    }
         Self {
             id: process.id(),
             node_id: process.node_id(),


### PR DESCRIPTION
`Protocol` previously required all the generics to implement `Debug` for `Protocol` itself to implement `Debug` to to the derive macro.

This PR implements `Debug` manually, using the type_name of the generics. This eases the requirement that each generic must implement `Debug`.

I didn't debug the `Z` generic, since I'm unsure what name to give it.