### PR TITLE
feat: allow new process ref to be created with unsafe

### DIFF
--- a/src/ap/builder.rs
+++ b/src/ap/builder.rs
@@ -157,7 +157,7 @@ where
     /// on the result in both cases to avoid deadlocks with the registry.
     #[track_caller]
     fn start_without_wait_on_init(&self, arg: T::Arg, init_tag: Tag) -> Process<(), T::Serializer> {
-        let this = Process::<Result<(), StartupError<T>>, T::Serializer>::this();
+        let this = unsafe { Process::<Result<(), StartupError<T>>, T::Serializer>::this() };
         let entry_data = (this, init_tag, arg);
         match (self.link, &self.config, self.node) {
             (Some(_), _, Some(_node)) => {

--- a/src/ap/messages.rs
+++ b/src/ap/messages.rs
@@ -14,7 +14,7 @@ where
     Serializer: CanSerialize<Response>,
 {
     pub(crate) fn from_self() -> Self {
-        let process = Process::this();
+        let process = unsafe { Process::this() };
         ReturnAddress { process }
     }
 

--- a/src/ap/mod.rs
+++ b/src/ap/mod.rs
@@ -271,7 +271,7 @@ impl<AP: AbstractProcess> Config<AP> {
 
     /// Get a reference to the running [`AbstractProcess`].
     pub fn self_ref(&self) -> ProcessRef<AP> {
-        let process = Process::this();
+        let process = unsafe { Process::this() };
         ProcessRef { process }
     }
 }
@@ -315,7 +315,7 @@ pub struct State<'a, AP: AbstractProcess> {
 impl<'a, AP: AbstractProcess> State<'a, AP> {
     /// Get a reference to the running [`AbstractProcess`].
     pub fn self_ref(&self) -> ProcessRef<AP> {
-        let process = Process::this();
+        let process = unsafe { Process::this() };
         ProcessRef { process }
     }
 }

--- a/src/function/process.rs
+++ b/src/function/process.rs
@@ -127,7 +127,8 @@ pub struct Process<M, S = Bincode> {
 }
 
 impl<M, S> Process<M, S> {
-    pub(crate) fn new(node_id: u64, process_id: u64) -> Self {
+    /// Creates a new process reference from a node_id and process_id.
+    pub unsafe fn new(node_id: u64, process_id: u64) -> Self {
         Self {
             node_id,
             id: process_id,
@@ -136,7 +137,7 @@ impl<M, S> Process<M, S> {
     }
 
     /// Return reference to self.
-    pub(crate) fn this() -> Self {
+    pub unsafe fn this() -> Self {
         Self::new(node_id(), process_id())
     }
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -4,9 +4,8 @@ use std::time::Duration;
 
 use crate::function::process::{IntoProcess, NoLink};
 use crate::host::api::message;
-use crate::host::{self};
 use crate::serializer::{Bincode, CanSerialize, DecodeError};
-use crate::{Process, ProcessConfig, Tag};
+use crate::{host, Process, ProcessConfig, Tag};
 
 pub const LINK_DIED: u32 = 1;
 pub const TIMEOUT: u32 = 9027;
@@ -134,7 +133,7 @@ where
 {
     /// Returns a reference to the currently running process
     pub fn this(&self) -> Process<M, S> {
-        Process::new(host::node_id(), host::process_id())
+        unsafe { Process::new(host::node_id(), host::process_id()) }
     }
 
     /// Same as `receive`, but doesn't panic in case the deserialization fails.
@@ -281,9 +280,9 @@ where
                 // If the captured variable is of size 0, we don't need to send it to another
                 // process.
                 if std::mem::size_of::<C>() == 0 {
-                    Process::new(node_id, id)
+                    unsafe { Process::new(node_id, id) }
                 } else {
-                    let child = Process::<C, S>::new(node_id, id);
+                    let child = unsafe { Process::<C, S>::new(node_id, id) };
                     child.send(capture);
                     // Processes can only receive one type of message, but to pass in the captured
                     // variable we pretend for the first message that our process is receiving

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -83,7 +83,7 @@ where
         // Don't drop the session yet.
         let self_ = ManuallyDrop::new(self);
         // Temporarily cast to right process type.
-        let process: Process<A, S> = Process::new(self_.node_id, self_.id);
+        let process: Process<A, S> = unsafe { Process::new(self_.node_id, self_.id) };
         process.tag_send(self_.tag, message);
         Protocol::from_process(process, self_.tag)
     }
@@ -140,7 +140,7 @@ where
         // Don't drop the session yet.
         let self_ = ManuallyDrop::new(self);
         // Temporarily cast to right process type.
-        let process: Process<bool, S> = Process::new(self_.node_id, self_.id);
+        let process: Process<bool, S> = unsafe { Process::new(self_.node_id, self_.id) };
         process.tag_send(self_.tag, true);
         Protocol::from_process(process, self_.tag)
     }
@@ -151,7 +151,7 @@ where
         // Don't drop the session yet.
         let self_ = ManuallyDrop::new(self);
         // Temporarily cast to right process type.
-        let process: Process<bool, S> = Process::new(self_.node_id, self_.id);
+        let process: Process<bool, S> = unsafe { Process::new(self_.node_id, self_.id) };
         process.tag_send(self_.tag, false);
         Protocol::from_process(process, self_.tag)
     }
@@ -312,13 +312,13 @@ where
                 // Use unique tag so that protocol messages are separated from regular messages.
                 let tag = Tag::new();
                 // Create reference to self
-                let this = Process::<()>::new(host::node_id(), host::process_id());
+                let this = unsafe { Process::<()>::new(host::node_id(), host::process_id()) };
                 let capture = ProtocolCapture {
                     process: this,
                     tag,
                     capture,
                 };
-                let child = Process::<ProtocolCapture<C>, S>::new(node_id, id);
+                let child = unsafe { Process::<ProtocolCapture<C>, S>::new(node_id, id) };
 
                 child.send(capture);
                 Protocol::from_process(child, tag)


### PR DESCRIPTION
The `Process::new` and Process::this` methods are sometimes useful (currently used in submillisecond-live-view) despite them being unsafe.

This PR makes these methods public, but marks them as unsafe.

In the future it might be worth considering adding a type `TaggedProcess` which allows a process to receive messages of a custom type through a tagged message. This would be safe and not require unsafe.